### PR TITLE
disable stack trace for AccessControlException.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
@@ -273,6 +273,7 @@ public class EmbeddedCDXServerIndex extends AbstractRequestHandler implements Me
 		HTTPSeekableLineReader reader = null;		
 		
 		// This will throw AccessControlException if blocked
+		// (in fact, it throws RuntimeIOException wrapping AccessControlException)
 		cdxServer.getAuthChecker().createAccessFilter(authToken).includeUrl(urlkey, query.getUrl());
 		
 		

--- a/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
+++ b/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
@@ -374,6 +374,13 @@ implements ShutdownListener {
 		if (LOGGER.isLoggable(Level.INFO)) {
 			if (e instanceof ResourceNotInArchiveException) {
 				this.logNotInArchive((ResourceNotInArchiveException)e, request);
+			} else if (e instanceof AccessControlException) {
+				// While StaticMapExclusionFilter#isExcluded(String) reports
+				// exclusion at INFO level, RobotExclusionFilter logs exclusion
+				// at FINE level only. I believe here is the better place to log
+				// exclusion. Unfortunately, AccessControlException has no
+				// detailed info (TODO). we don't need a stack trace.
+				LOGGER.log(Level.INFO, "Access Blocked:" + request.getRequestUrl() + ": "+ e.getMessage());
 			} else {
 				LOGGER.log(Level.INFO, "Runtime Error", e);
 			}


### PR DESCRIPTION
small change to disable stack trace for AccessControlException. it is an _expected_ exception, we don't need to see lousy stack trace in the log. this should also make it less painful to view build log on Jenkins.
