### PR TITLE
Fixes for LOC wayback

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/EmbeddedCDXServerIndex.java
@@ -29,6 +29,7 @@ import org.archive.util.io.RuntimeIOException;
 import org.archive.util.iterator.CloseableIterator;
 import org.archive.util.iterator.SortedCompositeIterator;
 import org.archive.wayback.ResourceIndex;
+import org.archive.wayback.UrlCanonicalizer;
 import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.core.CaptureSearchResults;
 import org.archive.wayback.core.SearchResults;
@@ -57,6 +58,7 @@ public class EmbeddedCDXServerIndex extends AbstractRequestHandler implements Me
 	protected int timestampDedupLength = 0;
 	protected int limit = 0;
 		
+	protected UrlCanonicalizer canonicalizer = null;
 	protected SelfRedirectFilter selfRedirFilter;
 	
 	protected String remoteCdxPath;
@@ -150,8 +152,21 @@ public class EmbeddedCDXServerIndex extends AbstractRequestHandler implements Me
     	//Compute url key (surt)
 		String urlkey = null;
 		
+		// If no canonicalizer is set, use selfRedirFilter's canonicalizer
+		// Either selfRedirFilter or a canonicalizer must be set
+		
+		UrlCanonicalizer canon = getCanonicalizer();
+		
+		if (canon == null && selfRedirFilter != null) {
+			canon = selfRedirFilter.getCanonicalizer();
+		}
+		
+		if (canon == null) {
+			throw new IllegalArgumentException("Unable to find canonicalizer, canonicalizer property or selfRedirFilter property must be set");
+		}
+		
 		try {
-			urlkey = selfRedirFilter.getCanonicalizer().urlStringToKey(wbRequest.getRequestUrl());
+			urlkey = canon.urlStringToKey(wbRequest.getRequestUrl());
 		} catch (URIException ue) {
 			throw new BadQueryException(ue.toString());
 		}
@@ -504,6 +519,14 @@ public class EmbeddedCDXServerIndex extends AbstractRequestHandler implements Me
 
 	public void setSelfRedirFilter(SelfRedirectFilter selfRedirFilter) {
 		this.selfRedirFilter = selfRedirFilter;
+	}
+
+	public UrlCanonicalizer getCanonicalizer() {
+		return canonicalizer;
+	}
+
+	public void setCanonicalizer(UrlCanonicalizer canonicalizer) {
+		this.canonicalizer = canonicalizer;
 	}
 
 	public int getLimit() {

--- a/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
+++ b/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
@@ -1020,10 +1020,13 @@ implements ShutdownListener {
 		if (warcHeaders != null) {
 			payloadUri = (String) warcHeaders.get("WARC-Refers-To-Target-URI");
 			
-			Date date = ArchiveUtils.parse14DigitISODate((String)warcHeaders.get("WARC-Refers-To-Date"), null);
+			String dateString = (String)warcHeaders.get("WARC-Refers-To-Date");
 			
-			if (date != null) {
-				payloadTimestamp = ArchiveUtils.get14DigitDate(date);
+			if (dateString != null) {
+				Date date = ArchiveUtils.parse14DigitISODate(dateString, null);
+				if (date != null) {
+					payloadTimestamp = ArchiveUtils.get14DigitDate(date);
+				}
 			}
 		}
 		


### PR DESCRIPTION
AccessPoint: fix possible NPE when resolving revisits and the WARC-Refers-To-Date header is null.
EmbeddedCDXServer: allow to specify a canonicalizer without a self-redirect filter, since self-redirect filter should not be used with revisit records that may refer to the record being filtered out.
