### PR TITLE
For https://webarchive.jira.com/browse/ARI-3680

### DIFF
--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/FieldRegexFilter.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/FieldRegexFilter.java
@@ -42,12 +42,6 @@ public class FieldRegexFilter implements CDXFilter {
 		
 		RegexMatch(String str)
 		{
-			try {
-				str = URLDecoder.decode(str, "UTF-8");
-			} catch (UnsupportedEncodingException e) {
-
-			}
-			
 			boolean contains = false;
 			
 			if (str.startsWith(CONTAINS_CHAR)) {


### PR DESCRIPTION
When using a custom canonicalization rule in ait-wayback's CustomCanonCDXIndex with an encoded url, a problem occurs if the urlkeys that are built contain encoded data. For example, if the url https://twitter.com/i/search/timeline?q=%23superbowl&src=unkn&include_available_features=1&include_entities=1&scroll_cursor=TWEET-452300485098500097-453943648778870784 is parsed by a regex that creates a urlkey with the value "q=%23superbowl", this value will be decoded into "q=#superbowl" and there won't be a match against the index, which causes a 404 error.

I hope this won't cause regressions in global wayback.
