### PR TITLE
Additional fix needed for https://webarchive.jira.com/browse/ARI-3745

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/WaybackConstants.java
+++ b/wayback-core/src/main/java/org/archive/wayback/WaybackConstants.java
@@ -33,6 +33,7 @@ public interface WaybackConstants {
 	 */
 	public static final String HTTP_URL_PREFIX = "http://";
 	public static final String HTTPS_URL_PREFIX = "https://";
+        public static final String HTTPS_URL_PREFIX_FOR_REWRITE_DECISION = "https";
 
 	/**
 	 * default HTTP port: 

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
@@ -74,7 +74,7 @@ public class ReplayParseContext extends ParseContext {
 			return true;
 		}
 		
-	    return url.startsWith(WaybackConstants.HTTPS_URL_PREFIX);
+	    return url.startsWith(WaybackConstants.HTTPS_URL_PREFIX_FOR_REWRITE_DECISION);
 	}
 
 	/**


### PR DESCRIPTION
It looks like some urls still aren't being rewritten from https to http in proxy mode. These are urls that are escaped. For example, in https://wayback.qa-archive-it.org/4311/20140421185901/https://www.flickr.com/photos/britishart/, there is "https:\/\/s.yimg.com\/pw\/combo\/1\/3.11.0?".

My fix works but I think there is a better way than just adding a new constant and referencing that to determine if replay is supported. I added the new constant because I didn't want to break any existing functionality. Feel free to reject this request and create a better solution. 
