### PR TITLE
For https://webarchive.jira.com/browse/ARI-3807

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/JSStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/JSStringTransformer.java
@@ -94,7 +94,7 @@ public class JSStringTransformer implements StringTransformer {
 					}
 				}
 			}
-			m.appendReplacement(replaced, pre + url + post);
+			m.appendReplacement(replaced, Matcher.quoteReplacement(pre + url + post));
 		}
 		m.appendTail(replaced);
 		return replaced.toString();


### PR DESCRIPTION
To fix regex rewriting problems in AIT, we want to only rewrite urls in JS that are enclosed in quotes (this will eliminate rewriting alot of JS regular expressions, which are hard to rewrite without causing syntax problems). Some quoted urls have special characters that can't be processed by Matcher so we want to make those urls be taken as literals by Java's regex engine. Forcing literal interpretation of special characters is what this change does by using Matcher.quoteReplacement to process the url before the regex appends it. An example of this problem can be seen at http://wayback.archive-it.org/1068/20140103173715id_/http://www.blogblog.com/dynamicviews/d6f37bb30c327165/js/magazine.js, which has the quoted url 'http://img2.blogblog.com/img/blogger_ad.html\' that contains the special character \ at the end. This url causes an exception when appendReplacement is called on it without Matcher.quoteReplacement.
