### PR TITLE
add UIResults.makePlainCaptureQueryUrl() for building plain and clean URL

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/core/UIResults.java
+++ b/wayback-core/src/main/java/org/archive/wayback/core/UIResults.java
@@ -255,6 +255,11 @@ public class UIResults {
 	/**
 	 * Create a self-referencing URL that will perform a query for all copies
 	 * of the given URL.
+	 * <p>This method builds URL that passes target URL in CGI parameter,
+	 * along with other parameters unnecessary for making simple capture
+	 * query request. It is not suitable for simple links.
+	 * {@link #makePlainCaptureQueryUrl(String)} generates clean and
+	 * plain URL.</p>
 	 * @param url to search for copies of
 	 * @return String url that will make a query for all captures of an URL.
 	 */
@@ -265,6 +270,19 @@ public class UIResults {
 		newWBR.setRequestUrl(url);
 		return newWBR.getAccessPoint().getQueryPrefix() + "query?" +
 			newWBR.getQueryArguments(1);
+	}
+
+	/**
+	 * Build a self-referencing URL that will perform a query for all copies
+	 * of the given URL (plain, clean URL version).
+	 * @param url URL to search for copies of
+	 * @return String URL for querying captures of
+	 * @version 1.8.1
+	 */
+	public String makePlainCaptureQueryUrl(String url) {
+		// TOOD: want "2014*" instead of "20140101000000-20141231115959*"
+		return wbRequest.getAccessPoint().makeCaptureQueryUrl(url,
+			wbRequest.getStartTimestamp(), wbRequest.getEndTimestamp());
 	}
 
 	/**

--- a/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
+++ b/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
@@ -1378,6 +1378,30 @@ implements ShutdownListener {
 	}
 
 	/**
+	 * Build a self-referencing URL that will perform a query for all copies
+	 * of URL {@code url}.
+	 * @param url URL to search for copies of
+	 * @param startdate start of date range in DT14 format (may be {@code null}
+	 * for no date range.
+	 * @param enddate end of date range in DT14 format (may be {@code null}, ignored
+	 * if {@code startdate} is {@code null})
+	 * @return String URL that will make a query for all captures of {@code url}.
+	 */
+	public String makeCaptureQueryUrl(String url, String startdate, String enddate) {
+		// XXX assumes particular style of query URL, which may not be compatible
+		// with RequestParsers in use. TODO: refactor.
+		if (startdate != null) {
+			if (enddate != null) {
+				return getQueryPrefix() + startdate + "-" + enddate + "*/" + url;
+			} else {
+				return getQueryPrefix() + startdate + "*/" + url;
+			}
+		} else {
+			return getQueryPrefix() + "*/" + url;
+		}
+	}
+
+	/**
 	 * @param interstitialJsp the interstitialJsp to set
 	 */
 	public void setInterstitialJsp(String interstitialJsp) {


### PR DESCRIPTION
for URL query (interim fix) addresses WWM-121 (unnecessarily long URL on URL query result page.)

chose ugly method name to retain old makeCaptureQueryUrl(). added a new method to AccessPoint because I plan to clean up URI-building classes/methods (URIConverter etc.).
