### PR TITLE
Ari 3992

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/util/htmllex/ParseContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/htmllex/ParseContext.java
@@ -132,7 +132,7 @@ public class ParseContext {
 	 * @return absolute form of input url, or url itself if javascript:
 	 */
 	public String contextualizeUrl(String url) {
-	    if(url.startsWith("javascript:")) {
+	    if(url.startsWith("javascript:") || url.startsWith("#")) {
 	    	return url;
 	    }
 		try {


### PR DESCRIPTION
This fix is to not "resolve" urls that begin with "#". The reason is due to the way the jquery ui tabs plugin handles these urls. The plugin checks whether the current location is the same as the relative anchor url and if it is not, the plugin calls the url and tries to load its content into the tab on the page. This causes the browser's screen to blank. There are a bunch of these issues over the last few months. The latest is https://webarchive.jira.com/browse/ARI-3992.
