### PR TITLE
Fix for https://webarchive.jira.com/browse/ARI-4061

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/locationdb/FlatFileResourceFileLocationDB.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/locationdb/FlatFileResourceFileLocationDB.java
@@ -61,6 +61,24 @@ public class FlatFileResourceFileLocationDB implements ResourceFileLocationDB  {
 				break;
 			}
 		}
+		
+		//if user has requested url without slash at end, check if any videos for url with slash at end
+		if (urls.size() == 0 && name.indexOf("?") == -1 && !name.endsWith("/")) {
+
+			prefix = name + "/" + delimiter;
+
+			itr = flatFile.getRecordIterator(prefix + "");
+
+			while (itr.hasNext()) {
+				String line = itr.next();
+				if (line.startsWith(prefix)) {
+					urls.add(line.substring(prefix.length()));
+				} else {
+					break;
+				}
+			}
+		}
+		
 		if(itr instanceof CloseableIterator) {
 			CloseableIterator<String> citr = (CloseableIterator<String>) itr;
 			citr.close();


### PR DESCRIPTION
If no videos found for a url without a querystring and trailing slash, append the flash and search again.
