### PR TITLE
Fix for video index issue related to https://webarchive.jira.com/browse/ARI-4082

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/locationdb/FlatFileResourceFileLocationDB.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/locationdb/FlatFileResourceFileLocationDB.java
@@ -77,24 +77,24 @@ public class FlatFileResourceFileLocationDB implements ResourceFileLocationDB  {
 					break;
 				}
 			}
-        } else if (name.indexOf("?") == -1 && name.endsWith("/")) {
-            // if url ends with trailing slash, do a search without the trailing
-            // slash since video may have been captured from no-slash page even
-            // though user is requesting the page with slash.
-            // canonicalizer will not remove trailing slash
-            prefix = name.substring(0, name.length() - 1) + delimiter;
+		} else if (name.indexOf("?") == -1 && name.endsWith("/")) {
+		    // if url ends with trailing slash, do a search without the trailing
+		    // slash since video may have been captured from no-slash page even
+		    // though user is requesting the page with slash.
+		    // canonicalizer will not remove trailing slash
+		    prefix = name.substring(0, name.length() - 1) + delimiter;
 
-            itr = flatFile.getRecordIterator(prefix + "");
+		    itr = flatFile.getRecordIterator(prefix + "");
 
-            while (itr.hasNext()) {
-                String line = itr.next();
-                if (line.startsWith(prefix)) {
-                    urls.add(line.substring(prefix.length()));
-                } else {
-                    break;
-                }
-            }
-        }
+		    while (itr.hasNext()) {
+		        String line = itr.next();
+		        if (line.startsWith(prefix)) {
+		            urls.add(line.substring(prefix.length()));
+		        } else {
+		            break;
+		        }
+		    }
+		}
 		
 		if(itr instanceof CloseableIterator) {
 			CloseableIterator<String> citr = (CloseableIterator<String>) itr;


### PR DESCRIPTION
Issue is that when user accesses https://wayback.archive-it.org/4280/20140625191711/http://www.maccabiusa.com/video/ (note trailing slash), the video that was captured at http://www.maccabiusa.com/video (note no trailing slash) is not found because the index contains the url without the trailing slash. This fix will detect if there is a trailing slash at the end of the search prefix and if so, remove it to do an additional query against the index without the trailing slash, adding any results to those that have already been found.

Not sure if the canonicalizer should have removed trailing slash from the prefix before the query??
