### PR TITLE
Fix for https://webarchive.jira.com/browse/ARI-4166

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
@@ -218,7 +218,8 @@ public class ReplayParseContext extends ParseContext {
 					.startsWith("https\\\\u00253A\\\\u00252F\\\\u00252F") &&
 				!trimmedUrl.startsWith("http:\\/\\/") &&
 				!trimmedUrl.startsWith("https:\\/\\/") &&
-				!trimmedUrl.startsWith("/")) {
+				!trimmedUrl.startsWith("/") &&
+				!trimmedUrl.startsWith(".")) {
 			return url;
 		}
 


### PR DESCRIPTION
Allow rewriting of path relative urls that begin with a dot. So ./path1 and ../path1 get rewritten.