### PR TITLE
Follow-up on issue-74: ensure backward compatibility

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCache.java
+++ b/wayback-core/src/main/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCache.java
@@ -38,6 +38,14 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 	
 	final static int STATUS_OK = 200;
 	final static int STATUS_ERROR = 502;
+	/**
+	 * old LiveWebCache did not communicate the specific statuscode
+	 * of live-web fetch. All HTTP failures were marked as 502, and
+	 * interpreted as "all allowed". Now that 5xx are "all disallow",
+	 * this non-standard 4xx status code is used for backward
+	 * compatibility.
+	 */
+	final static int STATUS_OLD_ERROR = 499;
 	
 	final static int MAX_ROBOTS_SIZE = 500000;
 	
@@ -57,7 +65,24 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 	final static String UPDATE_QUEUE_KEY = "robots_update_queue";
 	final static int MAX_UPDATE_QUEUE_SIZE = 50000;
 
+	// migration hack. until refreshTTL is elapsed since startup,
+	// 502 errors in cache are not trusted and refreshed immediately.
+	private final long startupTime;
+	private boolean inMigrationPeriod = false;
+	private static int MIN_UPDATE_INTERVAL = 30 * 60;
+	private final static String ROBOTS_OLD_TOKEN_ERROR = ROBOTS_TOKEN_ERROR + STATUS_ERROR;
+
+	public void setInMigrationPeriod(boolean inMigrationPeriod) {
+		this.inMigrationPeriod = inMigrationPeriod;
+	}
+	public boolean isInMigrationPeriod() {
+		return inMigrationPeriod;
+	}
 	
+	public SimpleRedisRobotsCache() {
+		this.startupTime = System.currentTimeMillis();
+	}
+
 	@Override
 	public Resource getCachedResource(URL urlURL, long maxCacheMS,
 				boolean bUseOlder) throws LiveDocumentNotAvailableException,
@@ -79,7 +104,20 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 		} finally {
 			PerfStats.timeEnd(PerfStat.RobotsRedis);
 		}
-		
+
+		// migration hack - don't trust cached 502 during migration period.
+		// old code records 404 as 502, which results in false blockage with
+		// new code. prevent too frequent updates.
+		if (value != null && inMigrationPeriod) {
+			if (ROBOTS_OLD_TOKEN_ERROR.equals(value.value) &&
+					(notAvailTotalTTL - value.ttl) > MIN_UPDATE_INTERVAL) {
+				long elapsedSec = (System.currentTimeMillis() - startupTime) / 1000;
+				if (elapsedSec < refreshTTL) {
+					value = null;
+				}
+			}
+		}
+
 		// Use the old liveweb cache, if provided
 		if (value == null) {
 			RobotsResult result = loadExternal(urlURL, maxCacheMS, bUseOlder);
@@ -130,7 +168,7 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 	
 	static boolean isFailedError(int status)
 	{
-		return (status == 0) || ((status >= 500));
+		return (status == 0) || ((status >= 500)) || status == STATUS_OLD_ERROR;
 	}
 	
 	static boolean isRedirect(int status)
@@ -247,8 +285,9 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 			}
 		} catch (LiveDocumentNotAvailableException ex) {
 			status = ex.getOriginalStatuscode();
+			// leave status == 0 as it is - for backward compatibility.
 			if (status == 0)
-				status = STATUS_ERROR;
+				status = STATUS_OLD_ERROR;
 		} catch (Exception e) {
 			LOGGER.log(Level.INFO, "Liveweb fetch failed for " + urlURL, e);
 			status = STATUS_ERROR;

--- a/wayback-core/src/main/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCache.java
+++ b/wayback-core/src/main/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCache.java
@@ -168,7 +168,7 @@ public class SimpleRedisRobotsCache implements LiveWebCache {
 	
 	static boolean isFailedError(int status)
 	{
-		return (status == 0) || ((status >= 500)) || status == STATUS_OLD_ERROR;
+		return (status == 0) || ((status >= 500));
 	}
 	
 	static boolean isRedirect(int status)

--- a/wayback-core/src/test/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCacheTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCacheTest.java
@@ -238,8 +238,8 @@ public class SimpleRedisRobotsCacheTest extends TestCase {
 		// cache shall be updated with 4xx error.
 		assertTrue(redisValueCapture.getValue().value
 			.startsWith(SimpleRedisRobotsCache.ROBOTS_TOKEN_ERROR + "4"));
-		// notAvailTotalTTL shall be used as TTL for errors.
-		assertEquals(cut.getNotAvailTotalTTL(), redisValueCapture.getValue().ttl);
+		// totalTTL shall be used as TTL for 4xx errors.
+		assertEquals(cut.getTotalTTL(), redisValueCapture.getValue().ttl);
 
 		EasyMock.verify(redisRobotsLogic, liveweb);
 	}

--- a/wayback-core/src/test/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCacheTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/accesscontrol/robotstxt/redis/SimpleRedisRobotsCacheTest.java
@@ -10,6 +10,7 @@ import org.archive.wayback.core.Resource;
 import org.archive.wayback.exception.LiveDocumentNotAvailableException;
 import org.archive.wayback.exception.LiveWebCacheUnavailableException;
 import org.archive.wayback.liveweb.LiveWebCache;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 
 /**
@@ -201,6 +202,44 @@ public class SimpleRedisRobotsCacheTest extends TestCase {
 			// expected, and ex must have the same status code.
 			assertEquals(STATUSCODE, ex.getOriginalStatuscode());
 		}
+
+		EasyMock.verify(redisRobotsLogic, liveweb);
+	}
+
+	/**
+	 * test of backward-compatibility with code using old interface
+	 * of LiveDocumentNotAvailableException.
+	 * @throws Exception
+	 */
+	public void testLiveFailureUnknown() throws Exception {
+		final int STATUSCODE = 404;
+		setupCached("http://example.com/robots.txt", null);
+		URL url = new URL("http://example.com/robots.txt");
+		//RobotsTxtResource resource = new RobotsTxtResource("/* robots.txt */");
+		//assert resource.getStatusCode() == 200;
+		EasyMock.expect(liveweb.getCachedResource(url, 0, false)).andThrow(
+			new LiveDocumentNotAvailableException("Invalid Status: " + STATUSCODE));
+		Capture<RedisValue> redisValueCapture = new Capture<RedisRobotsLogic.RedisValue>();
+		redisRobotsLogic.updateValue(EasyMock.eq(url.toString()),
+			EasyMock.capture(redisValueCapture),
+			EasyMock.eq(cut.isGzipRobots()));
+
+		EasyMock.replay(redisRobotsLogic, liveweb);
+
+		// Note r is not the same as resource
+		try {
+			cut.getCachedResource(url, 0, false);
+			fail();
+		} catch (LiveDocumentNotAvailableException ex) {
+			// expected, and ex shall have status code 4xx
+			int statuscode = ex.getOriginalStatuscode();
+			assertTrue(statuscode >= 400 && statuscode < 500);
+		}
+		// cache shall be updated with 4xx error.
+		assertTrue(redisValueCapture.getValue().value
+			.startsWith(SimpleRedisRobotsCache.ROBOTS_TOKEN_ERROR + "4"));
+		// notAvailTotalTTL shall be used as TTL for errors.
+		assertEquals(cut.getNotAvailTotalTTL(), redisValueCapture.getValue().ttl);
 
 		EasyMock.verify(redisRobotsLogic, liveweb);
 	}


### PR DESCRIPTION
when combined with old LiveWebCache implementation. 
Migrate old robots.txt caches automatically.
(internetarchive/wayback#74)