### PR TITLE
If status of next and prev captures are revisits, we can't be sure th…

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/core/FastCaptureSearchResult.java
+++ b/wayback-core/src/main/java/org/archive/wayback/core/FastCaptureSearchResult.java
@@ -139,6 +139,7 @@ public class FastCaptureSearchResult extends CaptureSearchResult {
 	public void flagDuplicateDigest(CaptureSearchResult payload) {
 		duplicateDigest = true;
 		revisitPayload = payload;
+		httpCode = payload.getHttpCode();
 	}
 	
 	public CaptureSearchResult getDuplicatePayload()

--- a/wayback-core/src/main/java/org/archive/wayback/replay/DefaultReplayCaptureSelector.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/DefaultReplayCaptureSelector.java
@@ -163,8 +163,8 @@ public class DefaultReplayCaptureSelector implements ReplayCaptureSelector {
 		boolean prev200 = (prevStatus != null) && prevStatus.equals("200");
 		boolean next200 = (nextStatus != null) && nextStatus.equals("200");
 
-		// If only one is a 200 and neither are revisits, prefer the entry with the 200
-		if (prev200 != next200 && (!("-").equals(prevStatus) && !("-").equals(nextStatus))) {
+		// If only one is a 200, prefer the entry with the 200
+		if (prev200 != next200) {
 			return (prev200 ? prev : next);
 		}
 

--- a/wayback-core/src/main/java/org/archive/wayback/replay/DefaultReplayCaptureSelector.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/DefaultReplayCaptureSelector.java
@@ -163,8 +163,8 @@ public class DefaultReplayCaptureSelector implements ReplayCaptureSelector {
 		boolean prev200 = (prevStatus != null) && prevStatus.equals("200");
 		boolean next200 = (nextStatus != null) && nextStatus.equals("200");
 
-		// If only one is a 200, prefer the entry with the 200
-		if (prev200 != next200) {
+		// If only one is a 200 and neither are revisits, prefer the entry with the 200
+		if (prev200 != next200 && (!("-").equals(prevStatus) && !("-").equals(nextStatus))) {
 			return (prev200 ? prev : next);
 		}
 


### PR DESCRIPTION
…at that the case of one status being not a 200 response is actually true. Fix for https://webarchive.jira.com/browse/ARI-4277