### PR TITLE
Fix: datelessReplayRequestParser throws NPE on invalid URL (including…

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/util/url/UrlOperations.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/url/UrlOperations.java
@@ -148,6 +148,8 @@ public class UrlOperations {
 	 * @return boolean indicating whether urlPart might be an Authority.
 	 */
 	public static boolean isAuthority(String authString) {
+		if (authString == null) return false;
+
 		Matcher m = AUTHORITY_REGEX.matcher(authString);
 		
 		return (m != null) && m.matches();

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlRequestParserTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlRequestParserTest.java
@@ -432,14 +432,11 @@ public class ArchivalUrlRequestParserTest extends TestCase {
 			WaybackRequest wbr = parse("/web/ftp:/www.yahoo.com/afile");
 			assertNull(wbr);
 		}
-		// scheme-relative - results in NullPointerException FIXME
+		// scheme-relative
 		{
-			try {
-				WaybackRequest wbr = parse("/web///www.yahoo.com/");
-				assertNull(wbr);
-			} catch (NullPointerException ex) {
-				// current behavior - FIXME.
-			}
+			WaybackRequest wbr = parse("/web///www.yahoo.com/");
+			assertNotNull(wbr);
+			assertEquals("http://www.yahoo.com/", wbr.getRequestUrl());
 		}
 		// regular case.
 		{

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/requestparser/DatelessReplayRequestParserTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/requestparser/DatelessReplayRequestParserTest.java
@@ -187,7 +187,7 @@ public class DatelessReplayRequestParserTest extends TestCase {
 		assertEquals("http://example.com/", wbr.getRequestUrl());
 	}
 
-	public void testUrlWithUserInfo() throws Exception {
+	public void testProtocolRelativeWithUserInfo() throws Exception {
 		setupRequest("//archive@example.com/");
 		EasyMock.replay(request);
 		try {
@@ -195,10 +195,6 @@ public class DatelessReplayRequestParserTest extends TestCase {
 			fail();
 		} catch (BadQueryException ex) {
 			// expected
-		} catch (NullPointerException ex) {
-			// results in this error currently.
-			System.err.println("needs fix");
-			ex.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
… protocol-relative URL).

Accept protocol-relative URLs.
Update test case (also renamed testUrlWithUserInfo to testProtocolRelativeWithUserInfo, which better represent what's really tested).