### PR TITLE
For https://webarchive.jira.com/browse/ARI-4561

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandler.java
@@ -81,7 +81,7 @@ public class FastArchivalUrlReplayParseEventHandler implements
 
 	private final String[] okHeadTags = { "![CDATA[*", "![CDATA[", "?",
 		"!DOCTYPE", "HTML", "HEAD", "BASE", "LINK", "META", "TITLE", "STYLE",
-		"SCRIPT", "BGSOUND" };
+		"SCRIPT", "BGSOUND", "NOSCRIPT" };
 	private HashMap<String, Object> okHeadTagMap = null;
 	private final static String FRAMESET_TAG = "FRAMESET";
 	private final static String BODY_TAG = "BODY";


### PR DESCRIPTION
Make noscript a valid tag within head section so when replaying https://wayback.archive-it.org/1646/20150923180532/http://viceprovost.tufts.edu/, wayback banner is added within body, not head tag.