### PR TITLE
Don't use quotesmart feature of HTML parser

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/util/htmllex/ContextAwareLexer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/util/htmllex/ContextAwareLexer.java
@@ -54,14 +54,14 @@ public class ContextAwareLexer extends NodeUtils {
 	public Node nextNode() throws ParserException {
 		Node node = null;
 		if (context.isInJS()) {
-			node = lexer.parseCDATA(true);
+			node = lexer.parseCDATA(false);
 			if (node != null) {
 				context.setInScriptText(true);
 				context.setInJS(false);
 				return node;
 			}
 		} else if (context.isInScriptText()) {
-			node = lexer.parseCDATA(true);
+			node = lexer.parseCDATA(false);
 			if (node != null) {
 				return node;
 			}

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -3,6 +3,7 @@ package org.archive.wayback.archivalurl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 import javax.servlet.ServletException;
@@ -1142,7 +1143,11 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 
     public String doEndToEnd(String input) throws Exception {
 		ByteArrayInputStream bais = new ByteArrayInputStream(input.getBytes(charSet));
-		
+		byte[] bytes = rewrite(bais);
+		return new String(bytes, outputCharset);
+    }
+    
+    public byte[] rewrite(InputStream is) throws Exception {
 		// To make sure we get the length, we have to buffer it all up...
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		context.setOutputStream(baos);
@@ -1150,7 +1155,7 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 
 		// and finally, parse, using the special lexer that knows how to
 		// handle javascript blocks containing unescaped HTML entities:
-		Page lexPage = new Page(bais,charSet);
+		Page lexPage = new Page(is, charSet);
 		Lexer lexer = new Lexer(lexPage);
 		Lexer.STRICT_REMARKS = false;
 		ContextAwareLexer lex = new ContextAwareLexer(lexer, context);
@@ -1162,7 +1167,7 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 		delegator.handleParseComplete(context);
 
 		// At this point, baos contains the utf-8 encoded bytes of our result:
-		return new String(baos.toByteArray(), outputCharset);
+		return baos.toByteArray();
 	}
 
 	// The followings checks expected (quirky) behaviors of HTMLParser.

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -921,6 +921,70 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
         assertEquals(expected, out);
 	}
 
+	/**
+	 * {@code </script>} in string literal shall not end script element.
+	 * Maybe this is too much to ask. It is a common practice to escape tag-look-alike
+	 * text in such a way as {@code '<' + '/script>'}.
+	 * @throws Exception
+	 */
+	public void testQuotedEndScriptTag() throws Exception {
+		delegator.setHeadInsertJsp("head.jsp");
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<html><head><script>a = '</script>';b='http://example.com/';</script></head>" +
+				"<body></body></html>";
+		final String expected = "<html><head>[[[JSP-INSERT:head.jsp]]]<script>a = '</script>';b='http://replay.archive.org/2001/http://example.com/';</script></head>" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]</body></html>";
+
+        String out = doEndToEnd(input);
+        //System.out.println(out);
+
+        assertEquals(expected, out);
+	}
+
+	/**
+	 * Similarly to the test above, other close tag text in string literal
+	 * shall not end script element.
+	 * @throws Exception
+	 */
+	public void testQuotedEndOtherTag() throws Exception {
+		delegator.setHeadInsertJsp("head.jsp");
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<html><head><script>a = '</div>';b='http://example.com/';</script></head>" +
+				"<body></body></html>";
+		final String expected = "<html><head>[[[JSP-INSERT:head.jsp]]]<script>a = '</div>';b='http://replay.archive.org/2001/http://example.com/';</script></head>" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]</body></html>";
+
+        String out = doEndToEnd(input);
+
+        assertEquals(expected, out);
+	}
+
+	/**
+	 * {@code </script>} in string literal shall not end script element.
+	 * Maybe this is too much to ask. It is a common practice to escape tag-look-alike
+	 * text in such a way as {@code '<' + '/script>'}.
+	 * @throws Exception
+	 */
+	public void testCommentedOutEndScriptTag() throws Exception {
+		delegator.setHeadInsertJsp("head.jsp");
+		delegator.setJspInsertPath("body-insert.jsp");
+		jspExec = new TestJSPExecutor();
+
+		final String input = "<html><head><script>// </script>\nb='http://example.com/';</script></head>" +
+				"<body></body></html>";
+		final String expected = "<html><head>[[[JSP-INSERT:head.jsp]]]<script>// </script>\nb='http://replay.archive.org/2001/http://example.com/';</script></head>" +
+				"<body>[[[JSP-INSERT:body-insert.jsp]]]</body></html>";
+
+        String out = doEndToEnd(input);
+        //System.out.println(out);
+
+        assertEquals(expected, out);
+	}
+
 	public void testCommentQuotesAndTagText() throws Exception {
 		// Currently there's a bug that JavaScript rewrite does not happen if headInsertJsp is null.
 		delegator.setHeadInsertJsp("head.jsp");

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -921,20 +921,38 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
         assertEquals(expected, out);
 	}
 
-	public void testElementLookAlikeInScript_2() throws Exception {
+	public void testCommentQuotesAndTagText() throws Exception {
 		// Currently there's a bug that JavaScript rewrite does not happen if headInsertJsp is null.
 		delegator.setHeadInsertJsp("head.jsp");
 		jspExec = new TestJSPExecutor();
 		// Note: existence of line comment and single quotes is important in this test - HTMLParser does some elaborate
-		// processing with them that fails to recognize close tag </script>.
-		final String input = "<html><head><script>\na=\"http://example.com/\";\n" +
-				"//p.append('<div class=\"sign\">+/-</div>');</script></head><body>http://example.com/</body></html>";
+		// processing with them that results in a failure to recognize close tag </script>.
+		final String input = "<html>\n" +
+				"<head>\n" +
+				"<script>\n" +
+				"a=\"http://example.com/\";\n" +
+				"// '</div>'\n" +
+				"</script>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"http://example.com/\n" +
+				"</body>\n" +
+				"</html>\n";
 		// URL in <body> must not be rewritten. If parser fails to recognize </script>, then it'll be rewritten by JavaScript transformer.
-		final String expected = "<html><head>[[[JSP-INSERT:head.jsp]]]<script>\na=\"http://replay.archive.org/2001/http://example.com/\";\n" +
-				"//p.append('<div class=\"sign\">+/-</div>');</script></head><body>http://example.com/</body></html>";
+		final String expected = "<html>\n" +
+				"<head>[[[JSP-INSERT:head.jsp]]]\n" +
+				"<script>\n" +
+				"a=\"http://replay.archive.org/2001/http://example.com/\";\n" +
+				"// '</div>'\n" +
+				"</script>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"http://example.com/\n" +
+				"</body>\n" +
+				"</html>\n";
 
 		String out = doEndToEnd(input);
-		System.out.println(out);
+		//System.out.println(out);
 
 		assertEquals(expected, out);
 	}

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -921,6 +921,24 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
         assertEquals(expected, out);
 	}
 
+	public void testElementLookAlikeInScript_2() throws Exception {
+		// Currently there's a bug that JavaScript rewrite does not happen if headInsertJsp is null.
+		delegator.setHeadInsertJsp("head.jsp");
+		jspExec = new TestJSPExecutor();
+		// Note: existence of line comment and single quotes is important in this test - HTMLParser does some elaborate
+		// processing with them that fails to recognize close tag </script>.
+		final String input = "<html><head><script>\na=\"http://example.com/\";\n" +
+				"//p.append('<div class=\"sign\">+/-</div>');</script></head><body>http://example.com/</body></html>";
+		// URL in <body> must not be rewritten. If parser fails to recognize </script>, then it'll be rewritten by JavaScript transformer.
+		final String expected = "<html><head>[[[JSP-INSERT:head.jsp]]]<script>\na=\"http://replay.archive.org/2001/http://example.com/\";\n" +
+				"//p.append('<div class=\"sign\">+/-</div>');</script></head><body>http://example.com/</body></html>";
+
+		String out = doEndToEnd(input);
+		System.out.println(out);
+
+		assertEquals(expected, out);
+	}
+
 	public void testXHTML() throws Exception {
 		delegator.setHeadInsertJsp("head.jsp");
 		delegator.setJspInsertPath("body-insert.jsp");


### PR DESCRIPTION
`FastArchivalUrlReplayParseEventHandler` uses _quotesmart_ feature of HTML parser while reading in-line JavaScript text.
It turned out HTML parser often gets confused by HTML tag text in JavaScript strings if this feature is turned on. Testing against several test cases, `FastArchivalUrlReplayParseEventHandler` worked just fine without this feature. So let's not use this feature.
This patch adds test cases illustrating the issue.

