### PR TITLE
Override the archived content type for CSS files.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRenderer.java
@@ -61,6 +61,7 @@ public class ArchivalUrlCSSReplayRenderer extends TextReplayRenderer {
 	 */
 	public ArchivalUrlCSSReplayRenderer(HttpHeaderProcessor httpHeaderProcessor) {
 		super(httpHeaderProcessor);
+		overrideContentMimeType = "text/css";
 	}
 
 	/* (non-Javadoc)

--- a/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
@@ -71,6 +71,8 @@ public abstract class TextReplayRenderer implements ReplayRenderer {
 	
 	public static String ORIG_ENCODING = "X-Archive-Orig-Encoding";
 
+	protected static String overrideContentMimeType = null;
+
 	private String guessedCharsetHeader = GUESSED_CHARSET_HEADER;
 	private List<String> jspInserts = null;
 	private HttpHeaderProcessor httpHeaderProcessor;
@@ -155,6 +157,9 @@ public abstract class TextReplayRenderer implements ReplayRenderer {
 		// let's try explicitly setting it to what we used:
 		httpResponse.setCharacterEncoding(page.getCharSet());
 
+        if (overrideContentMimeType != null && !overrideContentMimeType.isEmpty()) {
+            httpResponse.setContentType(overrideContentMimeType);
+        }
 		page.writeToOutputStream(httpResponse.getOutputStream());
 	}
 


### PR DESCRIPTION
Create MIME type flag on TextReplayRenderer
Set MIME type flag on ArchivalUrlCSSReplayRenderer