### PR TITLE
Inherit context flags from request URL during rewriting Location header field

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalURLJSStringTransformerReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalURLJSStringTransformerReplayRenderer.java
@@ -92,7 +92,7 @@ public class ArchivalURLJSStringTransformerReplayRenderer extends TextReplayRend
 		
 		// set up the context:
 		final ReplayParseContext context = ReplayParseContext.create(
-			uriConverter, converterFactory, result, rewriteHttpsOnly);
+			uriConverter, wbRequest, converterFactory, result, rewriteHttpsOnly);
 		
 		UIResults uiResults = new UIResults(wbRequest, uriConverter, results, result, resource);
 		JSPExecutor jspExec = new JSPExecutor(httpRequest, httpResponse, uiResults);

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlReplayURIConverter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlReplayURIConverter.java
@@ -27,6 +27,7 @@ import org.archive.url.URLParser;
 import org.archive.wayback.ReplayURIConverter;
 import org.archive.wayback.memento.MementoUtils;
 import org.archive.wayback.replay.ReplayContext;
+import org.archive.wayback.replay.ReplayRewriteContext;
 import org.archive.wayback.replay.ReplayURLTransformer;
 import org.archive.wayback.util.url.UrlOperations;
 import org.archive.wayback.webapp.AccessPoint;
@@ -201,6 +202,13 @@ public class ArchivalUrlReplayURIConverter implements ReplayURIConverter, Replay
 			absurl = replayContext.resolve(url);
 		} catch (URISyntaxException ex) {
 			return url;
+		}
+		// if flags is a special value identifying HTTP header field
+		// context, replace flags with request context flags. This way,
+		// rewritten Location header field will inherit context flags
+		// from the request.
+		if (ReplayRewriteContext.HEADER_CONTEXT.equals(flags)) {
+			flags = replayContext.getContextFlags();
 		}
 		// IMPORTANT: call makeReplayURI through replayContext.
 		// This is to allow for decorating ReplayURIConverter with

--- a/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRenderer.java
@@ -123,9 +123,8 @@ public class ArchivalUrlSAXRewriteReplayRenderer implements ReplayRenderer {
 		
 		// set up the context:
 		final ReplayParseContext context = ReplayParseContext.create(
-			uriConverter,
-			createConverterFactory(uriConverter, httpRequest, wbRequest),
-			result, rewriteHttpsOnly);
+			uriConverter, wbRequest,
+			createConverterFactory(uriConverter, httpRequest, wbRequest), result, rewriteHttpsOnly);
 
 		// XXX same code in ArchivalUrlJSStringReplayRenderer
 		String policy = result.getOraclePolicy();
@@ -170,7 +169,7 @@ public class ArchivalUrlSAXRewriteReplayRenderer implements ReplayRenderer {
 
 		// transform the original headers according to our headerProcessor:
 		Map<String,String> headers = HttpHeaderOperation.processHeaders(
-				httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+				httpHeadersResource, context, httpHeaderProcessor);
 
 		// prepare several objects for the parse:
 

--- a/wayback-core/src/main/java/org/archive/wayback/replay/HttpHeaderOperation.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/HttpHeaderOperation.java
@@ -67,11 +67,39 @@ public class HttpHeaderOperation {
 	}
 	
 	/**
+	 * Build replay header fields by applying {@code filter} on each
+	 * HTTP header fields in {@code resource}.
+	 * @param resource source of original HTTP header fields
+	 * @param context provides URL rewrite service
+	 * @param filter HTTP header field filter
+	 * @return replay header fields
+	 */
+	public static Map<String, String> processHeaders(Resource resource,
+			ReplayRewriteContext context, HttpHeaderProcessor filter) {
+		HashMap<String,String> output = new HashMap<String,String>();
+
+		// copy all HTTP headers, as-is, sending "" instead of nulls.
+		Map<String,String> headers = resource.getHttpHeaders();
+		if (headers != null) {
+			Iterator<String> itr = headers.keySet().iterator();
+			while(itr.hasNext()) {
+				String key = itr.next();
+				String value = headers.get(key);
+				value = (value == null) ? "" : value;
+				filter.filter(output, key, value, context);
+			}
+		}
+		return output;
+	}
+
+	/**
 	 * @param resource
 	 * @param result
 	 * @param uriConverter
-	 * @param filter 
+	 * @param filter
 	 * @return
+	 * @deprecated 2016-01-30 use
+	 *             {@link #processHeaders(Resource, ReplayRewriteContext, HttpHeaderProcessor)}
 	 */
 	public static Map<String,String> processHeaders(Resource resource, 
 			CaptureSearchResult result, ResultURIConverter uriConverter, 

--- a/wayback-core/src/main/java/org/archive/wayback/replay/HttpHeaderProcessor.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/HttpHeaderProcessor.java
@@ -70,14 +70,27 @@ public interface HttpHeaderProcessor {
 			HTTP_TRANSFER_ENCODING_HEADER.toUpperCase();
 	
 	/**
-	 * optionally add header key:value to output for later returning to client
-	 * 
+	 * optionally add header key:value to output for later returning to client.
+	 * <p>
+	 * Use {@link #filter(Map, String, String, ReplayRewriteContext)} instead.
+	 * This method will be deprecated.
+	 * </p>
 	 * @param output
 	 * @param key
 	 * @param value
-	 * @param uriConverter 
-	 * @param result 
+	 * @param uriConverter
+	 * @param result
 	 */
 	public void filter(Map<String,String> output, String key, String value,
 			final ResultURIConverter uriConverter, CaptureSearchResult result);
+
+	/**
+	 * Render HTTP header field {@code key}: {@code value} from Resource
+	 * @param output a map to save headers into
+	 * @param key header field name
+	 * @param value header field value
+	 * @param context provides access to projection scheme and capture information.
+	 */
+	public void filter(Map<String, String> output, String key, String value,
+			ReplayRewriteContext context);
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/IdentityHttpHeaderProcessor.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/IdentityHttpHeaderProcessor.java
@@ -19,10 +19,8 @@
  */
 package org.archive.wayback.replay;
 
-import java.util.Map;
-
-import org.archive.wayback.ResultURIConverter;
-import org.archive.wayback.core.CaptureSearchResult;
+import java.util.Arrays;
+import java.util.HashSet;
 
 /**
  * HttpHeaderProcessor which passes through all headers as-is.
@@ -38,14 +36,12 @@ import org.archive.wayback.core.CaptureSearchResult;
  */
 public class IdentityHttpHeaderProcessor extends PreservingHttpHeaderProcessor {
 
-	/* (non-Javadoc)
-	 * @see org.archive.wayback.replay.HttpHeaderProcessor#filter(java.util.Map, java.lang.String, java.lang.String, org.archive.wayback.ResultURIConverter, org.archive.wayback.core.CaptureSearchResult)
-	 */
-	public void filter(Map<String, String> output, String key, String value,
-			ResultURIConverter uriConverter, CaptureSearchResult result) {
-		if (key.equalsIgnoreCase(HTTP_TRANSFER_ENCODING_HEADER_UP))
-			preserve(output, key, value);
-		else
-			output.put(key, value);
+	public static final String[] DEFAULT_DROP_HEADERS = {
+		HTTP_TRANSFER_ENCODING_HEADER_UP
+	};
+
+	public IdentityHttpHeaderProcessor() {
+		dropHeaders = new HashSet<String>(Arrays.asList(DEFAULT_DROP_HEADERS));
 	}
+
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/PreservingHttpHeaderProcessor.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/PreservingHttpHeaderProcessor.java
@@ -1,21 +1,37 @@
 package org.archive.wayback.replay;
 
 import java.util.Map;
+import java.util.Set;
+
+import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.util.url.UrlOperations;
 
 /**
- * base class for {@link HttpHeaderProcessor} that preserves original headers
- * by prepending header name with given prefix.
+ * base class for {@link HttpHeaderProcessor} that preserves original headers by
+ * prepending header name with given prefix.
  * 
- * <p>use {@link #preserve(Map, String, String)} for headers that should not be
- * preserved if {@code prefix} is empty. use {@link #preserveAlways(Map, String, String)}
- * for headers that need to be preserved regardless of {@code prefix}.</p>
- * 
+ * <p>
+ * use {@link #preserve(Map, String, String)} for headers that should not be
+ * preserved if {@code prefix} is empty. use
+ * {@link #preserveAlways(Map, String, String)} for headers that need to be
+ * preserved regardless of {@code prefix}.
+ * </p>
+ * <p>
+ * This class now has base implementation of {@code filter} methods, which
+ * covers three types of headers: <i>PassThrough</i>, <i>Rewrite</i> and
+ * <i>Drop</i>.
+ * <p>
  * @author Kenji Nagahashi
  *
  */
 public abstract class PreservingHttpHeaderProcessor implements HttpHeaderProcessor {
 
 	protected String prefix = null;
+
+	protected Set<String> passThroughHeaders = null;
+	protected Set<String> rewriteHeaders = null;
+	protected Set<String> dropHeaders = null;
 
 	public String getPrefix() {
 		return prefix;
@@ -62,4 +78,43 @@ public abstract class PreservingHttpHeaderProcessor implements HttpHeaderProcess
 			output.put(prefix + name, value);
 		}
 	}
+
+	@Override
+	public void filter(Map<String, String> output, String key, String value,
+			ResultURIConverter uriConverter, CaptureSearchResult result) {
+		String ucKey = key.toUpperCase();
+		if (dropHeaders != null && dropHeaders.contains(ucKey))
+			preserve(output, key, value);
+		else
+			preserveAlways(output, key, value);
+		// rewrite header fields with URL values
+		if (rewriteHeaders != null && rewriteHeaders.contains(ucKey)) {
+			String baseUrl = result.getOriginalUrl();
+			String ts = result.getCaptureTimestamp();
+			// by the spec, value should be absolute already, but may
+			// not be in practice.
+			String url = UrlOperations.resolveUrl(baseUrl, value);
+			output.put(key,  uriConverter.makeReplayURI(ts, url));
+		} else if (passThroughHeaders != null && passThroughHeaders.contains(ucKey)) {
+			output.put(key, value);
+		}
+	}
+
+	@Override
+	public void filter(Map<String, String> output, String key, String value,
+			ReplayRewriteContext context) {
+		String ucKey = key.toUpperCase();
+		if (dropHeaders != null && dropHeaders.contains(ucKey))
+			preserve(output, key, value);
+		else
+			preserveAlways(output, key, value);
+		// rewrite header fields with URL values
+		if (rewriteHeaders != null && rewriteHeaders.contains(ucKey)) {
+			String replayUrl = context.contextualizeUrl(value, "hd_");
+			output.put(key,  replayUrl);
+		} else if (passThroughHeaders != null && passThroughHeaders.contains(ucKey)) {
+			output.put(key, value);
+		}
+	}
+
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/ReplayContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/ReplayContext.java
@@ -32,4 +32,11 @@ public interface ReplayContext {
 	 * @return projected replay URL
 	 */
 	public String makeReplayURI(String url, String flags, URLStyle urlStyle);
+
+	/**
+	 * Return flags specified in current request.
+	 * @return string like {@code "js_"} or {@code null}
+	 * @see org.archive.wayback.archivalurl.ArchivalUrl#getFlags(org.archive.wayback.core.WaybackRequest)
+	 */
+	public String getContextFlags();
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/ReplayRewriteContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/ReplayRewriteContext.java
@@ -1,0 +1,59 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.wayback.replay;
+
+/**
+ * Interface for URL-rewriting.
+ * Implementation encapsulates replay URL projection scheme, replay
+ * request being processed, and URL rewrite implementation that may be
+ * customized through ReplayURLTransformer interface.
+ * <p>
+ * Still not sure about this interface. This is necessary to allow
+ * HttpHeaderProcessor to call {@code contextualizeUrl} for rewriting
+ * URL in {@code Location} header. It cannot receive ReplayURLTransformer
+ * because it is intended for user customization. Perhaps {@code contextualizeUrl}
+ * can simply be part of ReplayContext interface.
+ * <p>
+ */
+public interface ReplayRewriteContext extends ReplayContext {
+	/**
+	 * Special {@code flags} value indicating URL is found in HTTP
+	 * response header.
+	 */
+	public static final String HEADER_CONTEXT = "hd_";
+
+	/**
+	 * Rewrite URL {@code url} in accordance with current replay mode, taking
+	 * replay context {@code flags} into account.
+	 * <p>
+	 * It is important to return the same String object {@code url} if no
+	 * rewrite is necessary, so that caller can short-circuit to avoid expensive
+	 * String operations.
+	 * </p>
+	 * @param url URL, candidate for rewrite. may contain escaping. must not be
+	 *        {@code null}.
+	 * @param flags <em>context</em> designator, such as {@code "cs_"}. can be
+	 *        {@code null}.
+	 * @return rewrittenURL, or {@code url} if no rewrite is necessary. never
+	 *         {@code null}.
+	 */
+	public String contextualizeUrl(final String url, String flags);
+}

--- a/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
@@ -20,6 +20,7 @@
 package org.archive.wayback.replay;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.archive.wayback.ReplayRenderer;
 import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.ReplayURIConverter.URLStyle;
 import org.archive.wayback.archivalurl.ArchivalUrlResultURIConverter;
 import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.core.CaptureSearchResults;
@@ -38,6 +40,7 @@ import org.archive.wayback.exception.BadContentException;
 import org.archive.wayback.replay.charset.CharsetDetector;
 import org.archive.wayback.replay.charset.StandardCharsetDetector;
 import org.archive.wayback.replay.html.ContextResultURIConverterFactory;
+import org.archive.wayback.replay.html.ReplayParseContext;
 
 /**
  * {@link ReplayRenderer} for rewriting textual resource with {@link TextDocument}.
@@ -112,10 +115,12 @@ public abstract class TextReplayRenderer implements ReplayRenderer {
 		// Decode resource (such as if gzip encoded)
 		Resource decodedResource = decodeResource(httpHeadersResource, payloadResource);
 		
+		ReplayParseContext context = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+
 		HttpHeaderOperation.copyHTTPMessageHeader(httpHeadersResource, httpResponse);
 
 		Map<String,String> headers = HttpHeaderOperation.processHeaders(
-				httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+				httpHeadersResource, context, httpHeaderProcessor);
 
 		String charSet = charsetDetector.getCharset(httpHeadersResource,
 				decodedResource, wbRequest);

--- a/wayback-core/src/main/java/org/archive/wayback/replay/TransparentReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TransparentReplayRenderer.java
@@ -34,6 +34,7 @@ import org.archive.wayback.core.CaptureSearchResults;
 import org.archive.wayback.core.Resource;
 import org.archive.wayback.core.WaybackRequest;
 import org.archive.wayback.exception.BadContentException;
+import org.archive.wayback.replay.html.ReplayParseContext;
 
 /**
  * ReplayRenderer implementation which returns the archive document as 
@@ -78,8 +79,10 @@ public class TransparentReplayRenderer implements ReplayRenderer {
 
 		HttpHeaderOperation.copyHTTPMessageHeader(httpHeadersResource, httpResponse);
 
+		ReplayParseContext context = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+
 		Map<String,String> headers = HttpHeaderOperation.processHeaders(
-				httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+				httpHeadersResource, context, httpHeaderProcessor);
 
 		// HACKHACK: getContentLength() may not find the original content length
 		// if a HttpHeaderProcessor has mangled it too badly. Should this

--- a/wayback-core/src/main/java/org/archive/wayback/replay/XArchiveHttpHeaderProcessor.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/XArchiveHttpHeaderProcessor.java
@@ -19,12 +19,8 @@
  */
 package org.archive.wayback.replay;
 
+import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import org.archive.wayback.ResultURIConverter;
-import org.archive.wayback.core.CaptureSearchResult;
 
 /**
  * {@link HttpHeaderProcessor} that renames all headers by prepending a prefix,
@@ -47,29 +43,19 @@ import org.archive.wayback.core.CaptureSearchResult;
  */
 public class XArchiveHttpHeaderProcessor extends PreservingHttpHeaderProcessor {
 
-	private static String DEFAULT_PREFIX = "X-Wayback-Orig-";
-	private Set<String> passThrough = null;
+	public static final String DEFAULT_PREFIX = "X-Wayback-Orig-";
+
+	public static final String[] DEFAULT_DROP_HEADERS = {
+		HTTP_TRANSFER_ENCODING_HEADER_UP
+	};
+	public static final String[] DEFAULT_PASSTHROUGH_HEADERS = {
+		HTTP_CONTENT_TYPE_HEADER_UP, HTTP_CONTENT_DISP_HEADER_UP,
+		HTTP_CONTENT_RANGE_HEADER_UP
+	};
 	
 	public XArchiveHttpHeaderProcessor() {
-		passThrough = new HashSet<String>();
-		passThrough.add(HTTP_CONTENT_TYPE_HEADER_UP);
-		passThrough.add(HTTP_CONTENT_DISP_HEADER_UP);
-		passThrough.add(HTTP_CONTENT_RANGE_HEADER_UP);
-
 		prefix = DEFAULT_PREFIX;
-	}
-	
-	public void filter(Map<String, String> output, String key, String value,
-			ResultURIConverter uriConverter, CaptureSearchResult result) {
-		String keyUp = key.toUpperCase();
-
-		if (key.equalsIgnoreCase(HTTP_TRANSFER_ENCODING_HEADER_UP))
-			preserve(output, key, value);
-		else
-			preserveAlways(output, key, value);
-		if (passThrough.contains(keyUp)) {
-			// add this one as-is, too.
-			output.put(key, value);
-		}
+		dropHeaders = new HashSet<String>(Arrays.asList(DEFAULT_DROP_HEADERS));
+		passThroughHeaders = new HashSet<String>(Arrays.asList(DEFAULT_PASSTHROUGH_HEADERS));
 	}
 }

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
@@ -29,9 +29,12 @@ import org.archive.wayback.ReplayURIConverter;
 import org.archive.wayback.ReplayURIConverter.URLStyle;
 import org.archive.wayback.ResultURIConverter;
 import org.archive.wayback.WaybackConstants;
+import org.archive.wayback.archivalurl.ArchivalUrl;
 import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.WaybackRequest;
 import org.archive.wayback.replay.JSPExecutor;
 import org.archive.wayback.replay.ReplayContext;
+import org.archive.wayback.replay.ReplayRewriteContext;
 import org.archive.wayback.replay.ReplayURLTransformer;
 import org.archive.wayback.util.htmllex.ParseContext;
 
@@ -51,8 +54,9 @@ import org.archive.wayback.util.htmllex.ParseContext;
  * TODO: consider replacing {@code CaptureSearchResult} reference with
  * {@code Capture}.
  */
-public class ReplayParseContext extends ParseContext implements ReplayContext {
+public class ReplayParseContext extends ParseContext implements ReplayRewriteContext {
 
+	private WaybackRequest wbRequest;
 	private String datespec = null;
 	private JSPExecutor jspExec = null;
 	private OutputStream outputStream = null;
@@ -199,11 +203,12 @@ public class ReplayParseContext extends ParseContext implements ReplayContext {
 	 * Initialize {@code ReplayParseContext} with URL translator object and
 	 * reference to target capture.
 	 * @param uriConverter TODO
-	 * @param replayUrlTransformer URL translator
 	 * @param result capture reference (originalUrl and captureTimestamp)
+	 * @param wbRequest TODO
+	 * @param replayUrlTransformer URL translator
 	 */
 	public ReplayParseContext(ReplayURIConverter uriConverter,
-			CaptureSearchResult result) {
+			CaptureSearchResult result, WaybackRequest wbRequest) {
 		this.result = result;
 		setBaseUrl(result.getOriginalUrl());
 		this.datespec = result.getCaptureTimestamp();
@@ -221,16 +226,17 @@ public class ReplayParseContext extends ParseContext implements ReplayContext {
 	 * {@link #ReplayParseContext(ContextResultURIConverterFactory, URL, String)}
 	 * otherwise.
 	 * @param uriConverter ResultURIConverter passed from access point.
+	 * @param wbRequest TODO
 	 * @param converterFactory contextualizing URI converter factory configured for ReplayRenderer.
 	 * @param result capture being replayed
 	 * @param rewriteHttpsOnly HTTPS rewrite flag
 	 */
 	@SuppressWarnings("deprecation")
 	public static ReplayParseContext create(ResultURIConverter uriConverter,
-			ContextResultURIConverterFactory converterFactory,
-			CaptureSearchResult result, boolean rewriteHttpsOnly) {
+			WaybackRequest wbRequest,
+			ContextResultURIConverterFactory converterFactory, CaptureSearchResult result, boolean rewriteHttpsOnly) {
 		if (uriConverter instanceof ReplayURIConverter) {
-			return new ReplayParseContext((ReplayURIConverter)uriConverter, result);
+			return new ReplayParseContext((ReplayURIConverter)uriConverter, result, wbRequest);
 		}
 		// backward-compatibility mode
 		final ContextResultURIConverterFactory fact;
@@ -257,13 +263,13 @@ public class ReplayParseContext extends ParseContext implements ReplayContext {
 	 * @param uriConverterFactory contextualized URI converter factory, must not be {@code null}.
 	 * @param result capture being replayed
 	 * @deprecated 2015-02-04 use
-	 *             {@link #ReplayParseContext(ReplayURIConverter, CaptureSearchResult)}
+	 *             {@link #ReplayParseContext(ReplayURIConverter, CaptureSearchResult, WaybackRequest)}
 	 *             .
 	 */
 	public ReplayParseContext(
 			ContextResultURIConverterFactory uriConverterFactory,
 			CaptureSearchResult result) {
-		this(new CompatReplayURIConverter(uriConverterFactory), result);
+		this(new CompatReplayURIConverter(uriConverterFactory), result, null);
 	}
 
 	/**
@@ -428,6 +434,17 @@ public class ReplayParseContext extends ParseContext implements ReplayContext {
 	@Override
 	public String makeReplayURI(String url, String flags, URLStyle urlStyle) {
 		return uriConverter.makeReplayURI(getDatespec(), url, flags, urlStyle);
+	}
+
+	@Override
+	public String getContextFlags() {
+		// compatibility with old code that does not pass
+		// WaybackRequest to ReplayParseContextx
+		if (wbRequest == null)
+			return null;
+		// TODO: this breaks encapsulation. should
+		// delegate to ReplayURIConverter?
+		return ArchivalUrl.getFlags(wbRequest);
 	}
 
 	/**

--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/ReplayParseContext.java
@@ -189,6 +189,13 @@ public class ReplayParseContext extends ParseContext implements ReplayRewriteCon
 			if (!isRewriteSupported(absurl)) {
 				return url;
 			}
+			// if flags is a special value identifying HTTP header field
+			// context, replace flags with request context flags. This way,
+			// rewritten Location header field will inherit context flags
+			// from the request.
+			if (ReplayRewriteContext.HEADER_CONTEXT.equals(flags)) {
+				flags = replayContext.getContextFlags();
+			}
 			return replayContext.makeReplayURI(absurl, flags, URLStyle.ABSOLUTE);
 		}
 
@@ -217,6 +224,7 @@ public class ReplayParseContext extends ParseContext implements ReplayRewriteCon
 			// TODO: default?
 		}
 		this.uriConverter = uriConverter;
+		this.wbRequest = wbRequest;
 	}
 
 	/**
@@ -247,7 +255,7 @@ public class ReplayParseContext extends ParseContext implements ReplayRewriteCon
 		} else {
 			fact = new IdentityResultURIConverterFactory(uriConverter);
 		}
-		return new ReplayParseContext(fact, result);
+		return new ReplayParseContext(new CompatReplayURIConverter(fact), result, wbRequest);
 	}
 
 	/**

--- a/wayback-core/src/main/java/org/archive/wayback/replay/swf/SWFReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/swf/SWFReplayRenderer.java
@@ -46,6 +46,7 @@ import org.archive.wayback.exception.BetterRequestException;
 import org.archive.wayback.exception.WaybackException;
 import org.archive.wayback.replay.HttpHeaderOperation;
 import org.archive.wayback.replay.HttpHeaderProcessor;
+import org.archive.wayback.replay.html.ReplayParseContext;
 import org.archive.wayback.util.url.UrlOperations;
 
 import com.flagstone.transform.DoAction;
@@ -99,9 +100,11 @@ public class SWFReplayRenderer implements ReplayRenderer {
 			// copy HTTP response code:
 			HttpHeaderOperation.copyHTTPMessageHeader(httpHeadersResource, httpResponse);
 
+			ReplayParseContext context = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+
 			// load and process original headers:
 			Map<String, String> headers = HttpHeaderOperation.processHeaders(
-					httpHeadersResource, result, uriConverter, httpHeaderProcessor);
+					httpHeadersResource, context, httpHeaderProcessor);
 
 			// The URL of the resource, for resolving embedded relative URLs:
 			URL url = null;

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/FastArchivalUrlReplayParseEventHandlerTest.java
@@ -54,7 +54,7 @@ public class FastArchivalUrlReplayParseEventHandlerTest extends TestCase {
 		// urlKey is not set as it is unused
 
 		// set up the context:
-		context = new ReplayParseContext(uriConverter, capture);
+		context = new ReplayParseContext(uriConverter, capture, null);
 		context.setOutputCharset(outputCharset);
 
 		delegator = new FastArchivalUrlReplayParseEventHandler();

--- a/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
@@ -62,6 +62,9 @@ public class TransparentReplayRendererTest extends TestCase {
         // use test fixture version as we want to focus on TransparentReplayRenderer behavior.
         uriConverter = EasyMock.createMock(ResultURIConverter.class);
         // result is only used in HttpHeaderOperation.processHeaders()
+        result = new CaptureSearchResult();
+        result.setOriginalUrl("http://exmaple.com/");
+        // CaptureSearchResults argument is unused.
         results = new CaptureSearchResults();
         
         response = EasyMock.createMock(HttpServletResponse.class);

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/ReplayParseContextTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/ReplayParseContextTest.java
@@ -1,0 +1,213 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.wayback.replay.html;
+
+import junit.framework.TestCase;
+
+import org.archive.wayback.ReplayURIConverter;
+import org.archive.wayback.ReplayURIConverter.URLStyle;
+import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.archivalurl.ArchivalUrlResultURIConverter;
+import org.archive.wayback.core.CaptureSearchResult;
+import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.replay.ReplayRewriteContext;
+import org.archive.wayback.replay.ReplayURLTransformer;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+
+/**
+ * Tests for {@link ReplayParseContext}.
+ */
+public class ReplayParseContextTest extends TestCase {
+
+	ReplayParseContext cut;
+
+	WaybackRequest wbRequest;
+	CaptureSearchResult result;
+	ReplayURIConverter uriConverter;
+	ReplayURLTransformer urlTransformer;
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see junit.framework.TestCase#setUp()
+	 */
+	protected void setUp() throws Exception {
+		super.setUp();
+		wbRequest = new WaybackRequest();
+
+		result = new CaptureSearchResult();
+		result.setOriginalUrl("http://www.example.com/top/index.html");
+		result.setCaptureTimestamp("20100203112233");
+
+		// set up a stub mock whose getURLTransformer() returns
+		// an object set to urlTransformer.
+		uriConverter = EasyMock.createMock(ReplayURIConverter.class);
+		EasyMock.expect(uriConverter.getURLTransformer()).andStubAnswer(
+			new IAnswer<ReplayURLTransformer>() {
+				@Override
+				public ReplayURLTransformer answer() throws Throwable {
+					return urlTransformer;
+				}
+			});
+	}
+
+	public void testResolve() throws Exception {
+		cut = new ReplayParseContext(uriConverter, result, wbRequest);
+		// uriConverter is not involved.
+		{
+			String resolved = cut.resolve("http://archive.org/help.html");
+			assertEquals("http://archive.org/help.html", resolved);
+		}
+		{
+			String resolved = cut.resolve("//archive.org/help.html");
+			assertEquals("http://archive.org/help.html", resolved);
+		}
+		{
+			String resolved = cut.resolve("/help.html");
+			assertEquals("http://www.example.com/help.html", resolved);
+		}
+		{
+			String resolved = cut.resolve("help.html");
+			assertEquals("http://www.example.com/top/help.html", resolved);
+		}
+		// special cases
+		{
+			String resolved = cut.resolve("javascript:alert()");
+			assertEquals("javascript:alert()", resolved);
+		}
+		{
+			String resolved = cut.resolve("/help.html#section1");
+			assertEquals("http://www.example.com/help.html#section1", resolved);
+		}
+	}
+
+	public void testMakeReplayURI() throws Exception {
+		final String DATESPEC = result.getCaptureTimestamp();
+		final String URL = "http://archive.org/help/contents.html";
+		final String FLAGS = "fw_";
+		final URLStyle URLSTYLE = URLStyle.SERVER_RELATIVE;
+
+		EasyMock.expect(
+			uriConverter.makeReplayURI(DATESPEC, URL, FLAGS, URLSTYLE))
+			.andReturn("/web/" + DATESPEC + FLAGS + "/" + URL);
+
+		EasyMock.replay(uriConverter);
+
+		cut = new ReplayParseContext(uriConverter, result, wbRequest);
+
+		cut.makeReplayURI(URL, FLAGS, URLSTYLE);
+	}
+
+	public void testGetContextFlags() throws Exception {
+		wbRequest.setFrameWrapperContext(true);
+
+		EasyMock.replay(uriConverter);
+
+		cut = new ReplayParseContext(uriConverter, result, wbRequest);
+
+		String flags = cut.getContextFlags();
+
+		assertEquals("fw_", flags);
+	}
+
+	public void testContextualizeUrl() throws Exception {
+		cut = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+	}
+
+	// tests for compatibility with previous versions
+
+	/**
+	 * If WaybackRequest is not given ({@code null}),
+	 * {@link ReplayParseContext#getContextFlags()} simply returns {@code null}.
+	 * @throws Exception
+	 */
+	public void testGetContextFlags_compat() throws Exception {
+		EasyMock.replay(uriConverter);
+
+		cut = new ReplayParseContext(uriConverter, result, null);
+
+		String flags = cut.getContextFlags();
+
+		assertNull(flags);
+	}
+
+	/**
+	 * Initialized with non-ReplayURIConverter, and {@code null} for {@code converterFactory},
+	 * ReplayParseContext uses old {@link ResultURIConverter#makeReplayURI(String, String)}
+	 * through IdentityResultURIConverterFactory, which simply ignores context flags.
+	 * @throws Exception
+	 */
+	public void testContextualizeUrl_compat() throws Exception {
+		final String OURL = "/help/content.html";
+		final String URL = "http://www.example.com" + OURL;
+		final String AURL = "http://web.archive.org/web/" + result.getCaptureTimestamp() + "/" + URL;
+		// hiding member field
+		ResultURIConverter uriConverter = EasyMock.createMock(ResultURIConverter.class);
+		EasyMock.expect(
+			uriConverter.makeReplayURI(result.getCaptureTimestamp(), URL))
+			.andReturn(AURL);
+
+		EasyMock.replay(uriConverter);
+
+		cut = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+
+		// HEADER_CONTEXT is canceled
+		String aurl = cut.contextualizeUrl(OURL, ReplayRewriteContext.HEADER_CONTEXT);
+
+		assertEquals(AURL, aurl);
+
+		EasyMock.verify(uriConverter);
+	}
+
+	/**
+	 * Old method of passing context flags to URL rewrite.
+	 * <p>
+	 * Now PreservingHttpHeaderProcessor passes special {@code HEADER_CONTEXT}
+	 * to {@link ReplayRewriteContext#contextualizeUrl(String, String)} when
+	 * rewriting {@code Location} header. This value must be replaced with
+	 * context flags in the request before calling
+	 * {@link ResultURIConverter#makeReplayURI(String, String)}.
+	 * </p>
+	 * @throws Exception
+	 */
+	@SuppressWarnings("deprecation")
+	public void testContextualizeUrl_factory() throws Exception {
+		ArchivalUrlResultURIConverter uriConverter = new ArchivalUrlResultURIConverter();
+		uriConverter.setReplayURIPrefix("http://web.archive.org/web/");
+
+		cut = ReplayParseContext.create(uriConverter, wbRequest, null, result, false);
+
+		String aurl = cut.contextualizeUrl("/help/content.html", "fw_");
+
+		assertEquals("http://web.archive.org/web/" +
+				result.getCaptureTimestamp() + "fw_/" +
+				"http://www.example.com/help/content.html", aurl);
+
+		// HEADER_CONTEXT is replaced with context flags in the request
+		wbRequest.setIFrameWrapperContext(true);
+		aurl = cut.contextualizeUrl("/help/content.html", ReplayRewriteContext.HEADER_CONTEXT);
+
+		assertEquals("http://web.archive.org/web/" +
+				result.getCaptureTimestamp() + "if_/" +
+				"http://www.example.com/help/content.html", aurl);
+	}
+}

--- a/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/JSStringTransformerTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/html/transformer/JSStringTransformerTest.java
@@ -177,7 +177,7 @@ public class JSStringTransformerTest extends TestCase {
 		// they should be refactored into coherent, easier-to-test components.) this is a common
 		// setup for proxy-mode (IdentityResultURIConverterFactory returns ProxyHttpsResultURIConverter.)
 		ReplayURIConverter uriConverter = new ProxyHttpsReplayURIConverter();
-		ReplayParseContext rc = new ReplayParseContext(uriConverter, result);
+		ReplayParseContext rc = new ReplayParseContext(uriConverter, result, null);
 		// Note: ParseContext.resolve(String) uses UsableURIFactory.getInstance() for
 		// making URL absolute. It not only prepends baseURL but also removes escaping
 		// like "\/", "%3A". So, depending on the URL pattern, more "\/" may be replaced
@@ -207,7 +207,7 @@ public class JSStringTransformerTest extends TestCase {
 	 */
 	public void testRewriteHttpsOnlyEscapedSlashesUnescaping() throws Exception {
 		ReplayURIConverter uriConverter = new ProxyHttpsReplayURIConverter();
-		ReplayParseContext rc = new ReplayParseContext(uriConverter, result);
+		ReplayParseContext rc = new ReplayParseContext(uriConverter, result, null);
 
 		final String input = "var img1 = 'http:\\/\\/example.com\\/img\\/1.jpeg';\n" +
 				"var img2 = 'https:\\/\\/secure1.example.com\\/img\\/2.jpeg';\n" +
@@ -239,7 +239,7 @@ public class JSStringTransformerTest extends TestCase {
 		ArchivalUrlReplayURIConverter uriConverter = new ArchivalUrlReplayURIConverter();
 		uriConverter.setReplayURIPrefix("http://web.archive.org/web/");
 
-		ReplayParseContext rc = new ReplayParseContext(uriConverter, result);
+		ReplayParseContext rc = new ReplayParseContext(uriConverter, result, null);
 
 		final String input = "var img1 = 'http:\\/\\/example.com\\/img\\/1.jpeg';\n" +
 				"var img2 = 'https:\\/\\/secure1.example.com\\/img\\/2.jpeg';\n" +
@@ -408,7 +408,7 @@ public class JSStringTransformerTest extends TestCase {
 				ReplayURIConverter uriConverter, CaptureSearchResult result) {
 			// these values must be non-null, but unused in tests.
 			// passed just to keep ReplayParseContext constructor happy.
-			super(uriConverter, result);
+			super(uriConverter, result, null);
 			this.mock = mock;
 		}
 


### PR DESCRIPTION
`HttpHeaderProcessor` implementations use `ResultURIConverter` passed from `AccessPoint` for rewriting `Location` header fields. Thus URL in `Location` header field will never have context flags. This results in page rendering failure when crawler archived more than one level of redirect responses from CSS / JavaScript link, and Wayback is configured to render interstitial redirect notice page for redirect captures. 

Without inheriting context flags, request URL loses context flags on the second redirect, and thus Wayback renders interstitial redirect page (HTML) with 200 status code, which browser parses as CSS / JavaScript and fail.

This pull request fixes this issue by passing `ReplayParseContext` to `HttpHeaderProcessor` (as new interface `ReplayRewriteContext`, and calling `contextualizeUrl` method with a special context flag indicating the URL is from `Location` header field. `ArchivalUrlReplayURIConverter` and `ReplayParseContext.CompatReplayURIConverter` are modified to replace this special context flag with context flags in request URL. `WaybackRequest` is added to the constructor argument of `ReplayParseContext` to support this behavior.

Change should be backward-compatible, and fixes the issue in Wayback configured with both old `ResultURIConverter` and new `ReplayURIConverter`.