### PR TITLE
FIX: GzipDecodingResource consumes first 2 bytes if the resource cont…

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TextReplayRenderer.java
@@ -251,19 +251,29 @@ public abstract class TextReplayRenderer implements ReplayRenderer {
 	 */
 	public static Resource decodeResource(Resource headersResource,
 			Resource payloadResource) throws IOException {
-		Map<String, String> headers = headersResource.getHttpHeaders();
+		// Content-Encoding may differ between headersResource and
+		// payloadResource. We use Content-Encoding of payloadResource,
+		// as we're reading content from it. Then update headersResource,
+		// as we're rendering headers from headersResource.
+		Map<String, String> headers = payloadResource.getHttpHeaders();
 
 		if (headers != null) {
 			String encoding = HttpHeaderOperation.getHeaderValue(headers,
 					HttpHeaderOperation.HTTP_CONTENT_ENCODING);
 			if (encoding != null) {
 				if (encoding.toLowerCase().equals(GzipDecodingResource.GZIP)) {
-					headers.put(ORIG_ENCODING, encoding);
-					HttpHeaderOperation.removeHeader(headers,
+					// if headersResource (revisit) has Content-Encoding, set it aside.
+					Map<String, String> revHeaders = headersResource.getHttpHeaders();
+					String revEncoding = HttpHeaderOperation.getHeaderValue(
+						revHeaders, HttpHeaderOperation.HTTP_CONTENT_ENCODING);
+					if (revEncoding != null) {
+						revHeaders.put(ORIG_ENCODING, encoding);
+						HttpHeaderOperation.removeHeader(revHeaders,
 							HttpHeaderOperation.HTTP_CONTENT_ENCODING);
+					}
 
-					if (HttpHeaderOperation.isChunkEncoded(headers)) {
-						HttpHeaderOperation.removeHeader(headers,
+					if (HttpHeaderOperation.isChunkEncoded(revHeaders)) {
+						HttpHeaderOperation.removeHeader(revHeaders,
 								HttpHeaderOperation.HTTP_TRANSFER_ENC_HEADER);
 					}
 

--- a/wayback-core/src/main/java/org/archive/wayback/resourcestore/jwat/JWATResource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourcestore/jwat/JWATResource.java
@@ -133,7 +133,7 @@ public class JWATResource extends Resource implements WARCConstants {
 					}
 					if (httpHeader != null) {
 						r.payloadStream = httpHeader.getPayloadInputStream();
-						r.length = httpHeader.payloadLength;
+						r.length = payload.getTotalLength();
 						r.status = httpHeader.statusCode;
 					} else if (payload != null) {
 						r.payloadStream = payload.getInputStreamComplete();

--- a/wayback-core/src/test/java/org/archive/wayback/replay/GzipDecodingResourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/GzipDecodingResourceTest.java
@@ -1,0 +1,100 @@
+/*
+ *  This file is part of the Wayback archival access software
+ *   (http://archive-access.sourceforge.net/projects/wayback/).
+ *
+ *  Licensed to the Internet Archive (IA) by one or more individual
+ *  contributors.
+ *
+ *  The IA licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.archive.wayback.replay;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import junit.framework.TestCase;
+
+import org.archive.io.warc.TestWARCReader;
+import org.archive.io.warc.TestWARCRecordInfo;
+import org.archive.io.warc.WARCRecord;
+import org.archive.io.warc.WARCRecordInfo;
+import org.archive.wayback.core.Resource;
+import org.archive.wayback.resourcestore.resourcefile.WarcResource;
+
+/**
+ * Test for GzipDecodingResource.
+ */
+public class GzipDecodingResourceTest extends TestCase {
+
+	public void testRegularGzipped() throws Exception {
+        final byte[] payload = "ABCDEFG".getBytes("UTF-8");
+        String ctype = "text/plain";
+		WARCRecordInfo recinfo = new TestWARCRecordInfo(
+			TestWARCRecordInfo.buildCompressedHttpResponseBlock(ctype, payload));
+        TestWARCReader ar = new TestWARCReader(recinfo);
+        WARCRecord rec = (WARCRecord)ar.get(0);
+        Resource resource = new WarcResource(rec, ar);
+        resource.parseHeaders();
+
+		GzipDecodingResource cut = new GzipDecodingResource(resource);
+
+		byte[] content = new byte[payload.length];
+		int n = cut.read(content);
+		cut.close();
+
+		// If GzipDecodingResource does not reset the input stream,
+		// we'll get 5, instead of expected 7.
+		assertEquals(payload.length, n);
+		assertEquals('A', content[0]);
+		assertEquals('B', content[1]);
+	}
+	/**
+	 * Sometimes response lies about content-encoding.
+	 * If content is not actually gzip-compressed, GzipDecodingResource
+	 * shall fall back on reading content as it is.
+	 * @throws Exception
+	 */
+	public void testNotGzipped() throws Exception {
+		// create HTTP response with false Content-Encoding
+		final byte[] payload = "ABCDEFG".getBytes("UTF-8");
+		ByteArrayOutputStream blockbuf = new ByteArrayOutputStream();
+		Writer w = new OutputStreamWriter(blockbuf);
+		w.write("HTTP/1.0 200 OK\r\n");
+		w.write("Content-Length: " + payload.length + "\r\n");
+		w.write("Content-Encoding: gzip\r\n");
+		w.write("\r\n");
+		w.flush();
+		blockbuf.write(payload);
+		w.close();
+		TestWARCRecordInfo recinfo = new TestWARCRecordInfo(blockbuf.toByteArray());
+
+		TestWARCReader ar = new TestWARCReader(recinfo);
+		WARCRecord rec = (WARCRecord)ar.get(0);
+		Resource resource = new WarcResource(rec, ar);
+		resource.parseHeaders();
+
+		GzipDecodingResource cut = new GzipDecodingResource(resource);
+
+		byte[] content = new byte[payload.length];
+		int n = cut.read(content);
+		cut.close();
+
+		// If GzipDecodingResource does not reset the input stream,
+		// we'll get 5, instead of expected 7.
+		assertEquals(payload.length, n);
+		assertEquals('A', content[0]);
+		assertEquals('B', content[1]);
+	}
+}

--- a/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/WarcResourceTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/resourcestore/resourcefile/WarcResourceTest.java
@@ -211,6 +211,8 @@ public class WarcResourceTest extends TestCase {
         // these are from this record.
         assertEquals("statusCode", 200, res.getStatusCode());
         assertEquals("content-type", ct, res.getHeader("Content-Type"));
+        // used for distinguishing new-style revisit record from old-style ones.
+        assertTrue(res.getRecordLength() > 0);
         
         StandardCharsetDetector csd = new StandardCharsetDetector();
         // assuming WaybackRequest (3rd parameter) is not used in getCharset()
@@ -252,6 +254,9 @@ public class WarcResourceTest extends TestCase {
         Map<String, String> headers = res.getHttpHeaders();
         //assertNotNull("headers", headers);
         assertNull("headers", headers);
+        
+        // this is used for detecting old-style revisit records.
+        assertTrue(res.getRecordLength() == 0);
         
         res.close();
     }


### PR DESCRIPTION
…ent is actually not gzip-compressed.

FIX: JWATResource.getRecordLength() always return 0 for revisit record.
FIX: TextReplayRenderer uses Content-Encoding in revisit record. It should have used the value in original.
Ref: ARI-4693