### PR TITLE
Pass CompositeResource to JSP for revisits so that JSP have access to…

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/JSPReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/JSPReplayRenderer.java
@@ -79,7 +79,9 @@ public class JSPReplayRenderer implements ReplayRenderer {
 			Resource payloadResource, ResultURIConverter uriConverter,
 			CaptureSearchResults results) throws ServletException, IOException,
 			WaybackException {
+		final Resource resource = payloadResource == httpHeadersResource ? payloadResource
+				: new CompositeResource(httpHeadersResource, payloadResource);
 		renderResource(httpRequest, httpResponse, wbRequest, result,
-				payloadResource, uriConverter, results);
+				resource, uriConverter, results);
 	}
 }


### PR DESCRIPTION
… HTTP headers in revisit record.

This is important for JSP that renders HTTP header field values, such as redirect notification page.
(WWM-330)