### PR TITLE
Use CompositeResource everywhere for handling revisit records

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/ReplayRenderer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/ReplayRenderer.java
@@ -90,6 +90,7 @@ public interface ReplayRenderer {
 	 * @throws IOException per usual
 	 * @throws WaybackException if Wayback data specific, anticipated exceptions
 	 *         occur
+	 * @deprecated 2016-03-08 Use one-Resource version above with CompositeResource.
 	 */
 	public void renderResource(HttpServletRequest httpRequest,
 			HttpServletResponse httpResponse, WaybackRequest wbRequest,

--- a/wayback-core/src/main/java/org/archive/wayback/core/Resource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/core/Resource.java
@@ -47,6 +47,12 @@ import org.apache.commons.httpclient.ChunkedInputStream;
  * @author Brad Tofel
  */
 public abstract class Resource extends InputStream {
+	
+	/**
+	 * Upper-case header field name for {@code Content-Encoding}.
+	 * For use with {@link #getHeader(String)}
+	 */
+	public static final String HTTP_CONTENT_ENCODING = "CONTENT-ENCODING";
 
 	private InputStream is;
 
@@ -113,6 +119,20 @@ public abstract class Resource extends InputStream {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Return <i>content-encoding</i> of the payload.
+	 * <p>
+	 * Currently meaningful for HTTP response resource only,
+	 * and returns the value of HTTP {@code Content-Encoding}.
+	 * Composite resource would override this method to return
+	 * a value from appropriate member Resource.
+	 * </p>
+	 * @return content-encoding header field value
+	 */
+	public String getContentEncoding() {
+		return getHeader(HTTP_CONTENT_ENCODING);
 	}
 
 	private void validate() throws IOException {

--- a/wayback-core/src/main/java/org/archive/wayback/replay/CompositeResource.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/CompositeResource.java
@@ -83,6 +83,14 @@ public class CompositeResource extends Resource {
 		else
 			return headersResource.getHeader(headerName);
 	}
+	/**
+	 * Returns {@code Content-Encoding} header field value
+	 * from the original record.
+	 */
+	@Override
+	public String getContentEncoding() {
+		return payloadResource.getHeader(HTTP_CONTENT_ENCODING);
+	}
 	@Override
 	public void setChunkedEncoding() throws IOException {
 		payloadResource.setChunkedEncoding();

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalURLJSStringTransformerReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalURLJSStringTransformerReplayRendererTest.java
@@ -157,7 +157,7 @@ public class ArchivalURLJSStringTransformerReplayRendererTest extends TestCase {
 		
 		EasyMock.replay(response);
 		
-		renderer.renderResource(request, response, wbRequest, result, payloadResource, payloadResource, proxyURIConverter, null);
+		renderer.renderResource(request, response, wbRequest, result, payloadResource, proxyURIConverter, null);
 		
 		String out = servletOutput.getString();
 		assertEquals("servlet output", expected, out);

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlCSSReplayRendererTest.java
@@ -125,7 +125,7 @@ public class ArchivalUrlCSSReplayRendererTest extends TestCase {
         
         EasyMock.replay(response, uriConverter);
         
-        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        cut.renderResource(null, response, wbRequest, result, payloadResource, uriConverter, null);
         
         EasyMock.verify(response, uriConverter);
         

--- a/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/archivalurl/ArchivalUrlSAXRewriteReplayRendererTest.java
@@ -17,6 +17,7 @@ import org.archive.wayback.ResultURIConverter;
 import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.core.Resource;
 import org.archive.wayback.core.WaybackRequest;
+import org.archive.wayback.replay.CompositeResource;
 import org.archive.wayback.replay.RedirectRewritingHttpHeaderProcessor;
 import org.archive.wayback.replay.TextReplayRenderer;
 import org.archive.wayback.replay.TransparentReplayRendererTest.TestServletOutputStream;
@@ -155,7 +156,7 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
 
         EasyMock.replay(nodeHandler, response, uriConverter);
 
-        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        cut.renderResource(null, response, wbRequest, result, payloadResource, uriConverter, null);
 
         EasyMock.verify(nodeHandler, response, uriConverter);
 
@@ -198,7 +199,8 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
 
         EasyMock.replay(nodeHandler, response, uriConverter);
 
-        cut.renderResource(null, response, wbRequest, result, headerResource, payloadResource, uriConverter, null);
+        Resource compResource = new CompositeResource(headerResource, payloadResource);
+        cut.renderResource(null, response, wbRequest, result, compResource, uriConverter, null);
 
         EasyMock.verify(nodeHandler, response, uriConverter);
 
@@ -280,7 +282,7 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
 
         EasyMock.replay(nodeHandler, response, uriConverter);
 
-        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        cut.renderResource(null, response, wbRequest, result, payloadResource, uriConverter, null);
 
         EasyMock.verify(nodeHandler, response, uriConverter);
 
@@ -319,7 +321,7 @@ public class ArchivalUrlSAXRewriteReplayRendererTest extends TestCase {
         // !!! KEY SETTING OF THIS TEST !!!
         wbRequest.setFrameWrapperContext(true);
 
-        cut.renderResource(null, response, wbRequest, result, payloadResource, payloadResource, uriConverter, null);
+        cut.renderResource(null, response, wbRequest, result, payloadResource, uriConverter, null);
 
         EasyMock.verify(nodeHandler, response, uriConverter);
 

--- a/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/TransparentReplayRendererTest.java
@@ -96,7 +96,6 @@ public class TransparentReplayRendererTest extends TestCase {
         WARCRecord rec = ar.get(0);
         Resource payloadResource = new WarcResource(rec, ar);
         payloadResource.parseHeaders();
-        Resource headersResource = payloadResource;
         
         TestServletOutputStream servletOutput = new TestServletOutputStream();
         response.setStatus(200);
@@ -110,7 +109,7 @@ public class TransparentReplayRendererTest extends TestCase {
         EasyMock.replay(response);
 
         cut.renderResource(request, response, wbRequest, result,
-                headersResource, payloadResource, uriConverter, results);
+                payloadResource, uriConverter, results);
         
         EasyMock.verify(response);
         byte[] content = servletOutput.getBytes();
@@ -135,7 +134,6 @@ public class TransparentReplayRendererTest extends TestCase {
         WARCRecord rec = ar.get(0);
         Resource payloadResource = new WarcResource(rec, ar);
         payloadResource.parseHeaders();
-        Resource headersResource = payloadResource;
         
         TestServletOutputStream servletOutput = new TestServletOutputStream();
         response.setStatus(200);
@@ -150,7 +148,7 @@ public class TransparentReplayRendererTest extends TestCase {
         EasyMock.replay(response);
 
         cut.renderResource(request, response, wbRequest, result,
-                headersResource, payloadResource, uriConverter, results);
+                payloadResource, uriConverter, results);
         
         EasyMock.verify(response);
         
@@ -193,7 +191,7 @@ public class TransparentReplayRendererTest extends TestCase {
         EasyMock.replay(response, uriConverter);
 
         cut.renderResource(request, response, wbRequest, result,
-                payloadResource, payloadResource, uriConverter, results);
+                payloadResource, uriConverter, results);
         
         EasyMock.verify(response, uriConverter);
 
@@ -229,7 +227,6 @@ public class TransparentReplayRendererTest extends TestCase {
         WARCRecord rec = ar.get(0);
         Resource payloadResource = new WarcResource(rec, ar);
         payloadResource.parseHeaders();
-        Resource headersResource = payloadResource;
 
         TestServletOutputStream servletOutput = new TestServletOutputStream();
         // expectations
@@ -246,8 +243,8 @@ public class TransparentReplayRendererTest extends TestCase {
 
         // creating separate test object to use IdentityHttpHeaderProcessor
         TransparentReplayRenderer cut2 = new TransparentReplayRenderer(new IdentityHttpHeaderProcessor());
-        cut2.renderResource(request, response, wbRequest, result,
-        		headersResource, payloadResource, uriConverter, results);
+		cut2.renderResource(request, response, wbRequest, result,
+			payloadResource, uriConverter, results);
 
         EasyMock.verify(response);
 


### PR DESCRIPTION
We've been still using old code passing Resources for revisit record and original capture separately. This patch converges on use of CompositeResource for all revisit cases.

