### PR TITLE
ARI-4812 handle quoted meta refresh URLs

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/MetaRefreshUrlStringTransformer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/html/transformer/MetaRefreshUrlStringTransformer.java
@@ -43,7 +43,7 @@ import org.archive.wayback.replay.html.ReplayParseContext;
 public class MetaRefreshUrlStringTransformer extends URLStringTransformer {
 
 	private final static Pattern refreshURLPattern = Pattern.compile(
-			"^[\\d.]+\\s*;\\s*url\\s*=\\s*(.+?)\\s*$", Pattern.CASE_INSENSITIVE
+			"^[\\d.]+\\s*;\\s*url\\s*=\\s*\\'?(.+?)\\'?\\s*$", Pattern.CASE_INSENSITIVE
 					| Pattern.MULTILINE);
 
 	/*


### PR DESCRIPTION
I also tried using `&#39;` for the single quotes, but those are not handled properly, while `\\'` is handled properly; I verified running wayback locally.