### PR TITLE
FIX: selfRedirectCanonicalizer in CompositeAccessPoint is ignored and…

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
+++ b/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPoint.java
@@ -47,6 +47,7 @@ import org.archive.wayback.ReplayURIConverter.URLStyle;
 import org.archive.wayback.RequestParser;
 import org.archive.wayback.ResourceStore;
 import org.archive.wayback.ResultURIConverter;
+import org.archive.wayback.UrlCanonicalizer;
 import org.archive.wayback.accesscontrol.AuthContextExclusionFilterFactory;
 import org.archive.wayback.accesscontrol.CollectionContext;
 import org.archive.wayback.accesscontrol.ContextExclusionFilterFactory;
@@ -83,7 +84,6 @@ import org.archive.wayback.resourceindex.cdxserver.EmbeddedCDXServerIndex;
 import org.archive.wayback.resourceindex.filters.ExclusionFilter;
 import org.archive.wayback.resourceindex.filters.WARCRevisitAnnotationFilter;
 import org.archive.wayback.util.operator.BooleanOperator;
-import org.archive.wayback.util.webapp.AbstractRequestHandler;
 import org.archive.wayback.util.webapp.ShutdownListener;
 import org.archive.wayback.webapp.LiveWebRedirector.LiveWebState;
 
@@ -129,6 +129,7 @@ public class AccessPoint extends AccessPointBase implements
 		AccessPoint.class.getName());
 
 	private boolean exactHostMatch = false;
+	private boolean exactSchemeMatch = false;
 	private boolean useAnchorWindow = false;
 	private boolean useServerName = false;
 	private boolean serveStatic = true;
@@ -191,6 +192,8 @@ public class AccessPoint extends AccessPointBase implements
 
 	private long embargoMS = 0;
 	private CustomResultFilterFactory filterFactory = null;
+
+	private UrlCanonicalizer selfRedirectCanonicalizer = null;
 
 	private int maxRedirectAttempts = 0;
 
@@ -1216,6 +1219,21 @@ public class AccessPoint extends AccessPointBase implements
 	 */
 
 	/**
+	 * @return the exactSchemeMatch
+	 */
+	@Override
+	public boolean isExactSchemeMatch() {
+		return exactSchemeMatch;
+	}
+
+	/**
+	 * @param exactSchemeMatch the exactSchemeMatch to set
+	 */
+	public void setExactSchemeMatch(boolean exactSchemeMatch) {
+		this.exactSchemeMatch = exactSchemeMatch;
+	}
+
+	/**
 	 * @return the exactHostMatch
 	 */
 	public boolean isExactHostMatch() {
@@ -1758,6 +1776,24 @@ public class AccessPoint extends AccessPointBase implements
 	 */
 	public CustomResultFilterFactory getFilterFactory() {
 		return filterFactory;
+	}
+
+	/**
+	 * Optional
+	 * @param selfRedirectCanonicalizer
+	 */
+	public void setSelfRedirectCanonicalizer(
+			UrlCanonicalizer selfRedirectCanonicalizer) {
+		this.selfRedirectCanonicalizer = selfRedirectCanonicalizer;
+	}
+
+	/**
+	 * URL canonicalizer for testing self-redirect.
+	 * @return UrlCanonicalizer
+	 */
+	@Override
+	public UrlCanonicalizer getSelfRedirectCanonicalizer() {
+		return this.selfRedirectCanonicalizer;
 	}
 
 	public int getMaxRedirectAttempts() {

--- a/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPointBase.java
+++ b/wayback-core/src/main/java/org/archive/wayback/webapp/AccessPointBase.java
@@ -23,6 +23,7 @@ package org.archive.wayback.webapp;
 import java.io.IOException;
 
 import org.archive.wayback.UrlCanonicalizer;
+import org.archive.wayback.accesspoint.AccessPointAdapter;
 import org.archive.wayback.core.CaptureSearchResult;
 import org.archive.wayback.core.Resource;
 import org.archive.wayback.core.WaybackRequest;
@@ -33,11 +34,12 @@ import org.archive.wayback.util.webapp.AbstractRequestHandler;
  * AccessPointBase provides fields and methods common to AbstractRequestHandler
  * implementations for core wayback machine functionalities (playback, search,
  * live web archiving, etc.)
+ * 
+ * Note: this class should not have fields whose getter is overridden in {@link AccessPointAdapter}.
+ * If you need to access those fields, be sure to declare an abstract getter method, and access
+ * the value through it.
  */
 public abstract class AccessPointBase extends AbstractRequestHandler {
-
-	private boolean exactSchemeMatch = false;
-	private UrlCanonicalizer selfRedirectCanonicalizer = null;
 
 	protected boolean isSelfRedirect(Resource resource,
 			CaptureSearchResult closest, WaybackRequest wbRequest,
@@ -100,37 +102,21 @@ public abstract class AccessPointBase extends AbstractRequestHandler {
 	/**
 	 * @return the exactSchemeMatch
 	 */
-	public boolean isExactSchemeMatch() {
-		return exactSchemeMatch;
-	}
-
-	/**
-	 * @param exactSchemeMatch the exactSchemeMatch to set
-	 */
-	public void setExactSchemeMatch(boolean exactSchemeMatch) {
-		this.exactSchemeMatch = exactSchemeMatch;
-	}
-
-	/**
-	 * Optional
-	 * @param selfRedirectCanonicalizer
-	 */
-	public void setSelfRedirectCanonicalizer(UrlCanonicalizer selfRedirectCanonicalizer) {
-		this.selfRedirectCanonicalizer = selfRedirectCanonicalizer;
-	}
+	public abstract boolean isExactSchemeMatch();
 
 	/**
 	 * URL canonicalizer for testing self-redirect.
 	 * @return UrlCanonicalizer
 	 */
-	public UrlCanonicalizer getSelfRedirectCanonicalizer() {
-		return selfRedirectCanonicalizer;
-	}
+	public abstract UrlCanonicalizer getSelfRedirectCanonicalizer();
 
 	protected String urlToKey(String url) {
-		if (selfRedirectCanonicalizer != null) {
+		// getSelfRedirectCanonicalizer() can be overridden in a sub-class.
+		// Always access selfRedirectCanonicalizer through getter method.
+		UrlCanonicalizer canonicalizer = getSelfRedirectCanonicalizer();
+		if (canonicalizer != null) {
 			try {
-				return selfRedirectCanonicalizer.urlStringToKey(url);
+				return canonicalizer.urlStringToKey(url);
 			} catch (IOException ex) {
 			}
 		}


### PR DESCRIPTION
… causes infinite redirect loop with self-redirect captures.

	`urlToKey()` method accesses `selfRedirectCanonicalizer` directly. It should have accessed it through the getter method.
	Move `exactSchemeMatch` and `selfRedirectCanonicalizer` back to AccessPoint to prevent future errors of the same sort. `AccessPointBase` now accesses those fields through abstract getter methods. Added a cautionary documentation to `AccessPointBase`.

ARI-5234