### PR TITLE
Expand CSS parsing RegEx to include URLs with "(" and ")" chars.

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/TagMagix.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/TagMagix.java
@@ -68,7 +68,7 @@ public class TagMagix {
 			+ RAW_ATTR_VALUE;
 	
 	private static String cssUrlPatString = 
-		"(?<!@namespace [\\w\\s]{0,16})url\\s*\\(\\s*([\\\\\"']*.*?[\\\\\"']*)\\s*\\)";
+		"(?<!@namespace [\\w\\s]{0,16})url\\s*\\(\\s*([\\\\\"']*.*?[\\\\\"']*)\\s*\\)(?![^\\s;])";
 
 	private static String cssImportNoUrlPatString =
 		"@import\\s+([\"'].+?[\"'])";

--- a/wayback-core/src/test/java/org/archive/wayback/replay/TagMagixTest.java
+++ b/wayback-core/src/test/java/org/archive/wayback/replay/TagMagixTest.java
@@ -389,7 +389,11 @@ public class TagMagixTest extends TestCase {
 		checkStyleUrlMarkup("<table style='background: url(/css/b.gif)'></table>",
 				"<table style='background: url(http://w.a.org/wb/2004/http://f.au/css/b.gif)'></table>",
 				"http://w.a.org/wb/","2004","http://f.au/");
-		
+		// url path with "()" in path
+		checkStyleUrlMarkup("<table style='background: url(/css/b(foo).gif)'></table>",
+				"<table style='background: url(http://w.a.org/wb/2004/http://f.au/css/b(foo).gif)'></table>",
+				"http://w.a.org/wb/","2004","http://f.au/");
+
 		// quote attribute, apos url:
 		checkStyleUrlMarkup("<table style=\"background: url('/css/b.gif')\"></table>",
 				"<table style=\"background: url('http://w.a.org/wb/2004/http://f.au/css/b.gif')\"></table>",


### PR DESCRIPTION
This change uses a positive RegEx lookahead to ensure we're at the end of a quoted statement, property config, or whitespace as the next character.

This fixes a problem parsing the `style.css` stylesheet for https://www.cpsc.gov/.