### PR TITLE
Refactoring CDXServer processor code for coming extension of CDX

### DIFF
--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/CollapseFieldFilter.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/CollapseFieldFilter.java
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.math.NumberUtils;
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 import org.archive.format.cdx.FieldSplitLine;
 
 /**
@@ -24,7 +24,7 @@ public class CollapseFieldFilter implements CDXFilter {
 
 	final static String FIELD_SEP_CHAR = ":";
 
-	final protected FieldSplitFormat names;
+	final protected CDXFormat names;
 	final protected List<DupeMatch> dupeMatchers;
 
 	class DupeMatch {
@@ -87,7 +87,7 @@ public class CollapseFieldFilter implements CDXFilter {
 		}
 	}
 
-	public CollapseFieldFilter(String[] fields, FieldSplitFormat names) {
+	public CollapseFieldFilter(String[] fields, CDXFormat names) {
 		this.names = names;
 
 		this.dupeMatchers = new ArrayList<DupeMatch>(fields.length);

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/FieldRegexFilter.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/filter/FieldRegexFilter.java
@@ -1,13 +1,11 @@
 package org.archive.cdxserver.filter;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 import org.archive.format.cdx.FieldSplitLine;
 
 /**
@@ -31,7 +29,7 @@ public class FieldRegexFilter implements CDXFilter {
 	final static String CONTAINS_CHAR = "~";
 	final static String FIELD_SEP_CHAR = ":";
 	
-	final protected FieldSplitFormat names;
+	final protected CDXFormat names;
 	final protected List<RegexMatch> regexMatchers;
 	
 	class RegexMatch {
@@ -126,9 +124,9 @@ public class FieldRegexFilter implements CDXFilter {
 	}
 	
 	
-	public FieldRegexFilter(String[] regexs, FieldSplitFormat names)
+	public FieldRegexFilter(String[] regexs, CDXFormat names)
 	{
-	  this.names = names;
+		this.names = names;
 		this.regexMatchers = new ArrayList<RegexMatch>(regexs.length);
 		
 		for (String regex : regexs) {

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX11Format.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX11Format.java
@@ -1,0 +1,23 @@
+/**
+ * 
+ */
+package org.archive.cdxserver.format;
+
+import org.archive.format.cdx.StandardCDXLineFactory;
+
+/**
+ * A StandardCDXFormat sub-class representing standard CDX11 format.
+ *
+ */
+public class CDX11Format extends StandardCDXFormat {
+	public CDX11Format() {
+		super(new StandardCDXLineFactory("cdx11"), urlkey, timestamp, original,
+			mimetype, statuscode, digest, redirect, robotflags, length, offset,
+			filename);
+	}
+
+	@Override
+	public String toString() {
+		return "cdx11";
+	}
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX9Format.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX9Format.java
@@ -1,0 +1,21 @@
+/**
+ * 
+ */
+package org.archive.cdxserver.format;
+
+import org.archive.format.cdx.StandardCDXLineFactory;
+
+/**
+ * A StandardCDXFormat sub-class representing standard CDX9 format.
+ */
+public class CDX9Format extends StandardCDXFormat {
+	public CDX9Format() {
+		super(new StandardCDXLineFactory("cdx9"), urlkey, timestamp, original,
+			mimetype, statuscode, digest, redirect, offset, filename);
+	}
+
+	@Override
+	public String toString() {
+		return "cdx9";
+	}
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDXFormat.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDXFormat.java
@@ -1,0 +1,64 @@
+package org.archive.cdxserver.format;
+
+import org.archive.format.cdx.CDXLine;
+import org.archive.format.cdx.FieldSplitFormat;
+
+/**
+ * CDXFormat serves as customization point for CDX line format.
+ * <p>
+ * CDX line format had been represented by {@link FieldSplitFormat}, which is essentially
+ * a list of field names with methods to manipulate them, and {@link CDXLineFactory}, which
+ * serves as a factory of {@link CDXLine} sub-classes.
+ * CDXFormat interface encapsulate these two classes behind single interface, and also serves
+ * as customization point for the way how certain capture characteristics are represented in
+ * CDX line fields, like revisit capture, for example.
+ * </p>
+ */
+public interface CDXFormat {
+
+	/**
+	 * Parses {@code input} and return CDXLine.
+	 * <p>
+	 * This method replaces CDXLineFactory#createStandardCDXLine(String, FieldSplitFormat)
+	 * @param input string data from index files.
+	 * @return CDXLine
+	 */
+	public CDXLine createCDXLine(String input);
+	
+	/**
+	 * Return a list of field names.
+	 * @return FieldSplitFormat object
+	 */
+	public FieldSplitFormat getFields();
+	
+	/**
+	 * Return index of field {@code fieldName}.
+	 * <p>
+	 * Used with {@link CDXLine#getField(int)} to access field data
+	 * efficiently.
+	 * </p>
+	 * @param field
+	 * @return zero-based index
+	 */
+	public int getFieldIndex(String fieldName);
+	
+	/**
+	 * Return new instance with existing fields plus {@code newFields},
+	 * maintaining other traits.
+	 * <p>
+	 * Equivalent of {@link FieldSplitFormat#addFieldNames(String...)}.
+	 * </p>
+	 * @param newFields
+	 * @return CDXFormat
+	 */
+	public CDXFormat extend(String... newFields);
+	
+	/**
+	 * Implements customizable logic of determining {@code line} is
+	 * a revisit capture or not.
+	 * @param line capture
+	 * @return
+	 */
+	public boolean isRevisit(CDXLine line);
+
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDXFormatEditor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDXFormatEditor.java
@@ -1,0 +1,35 @@
+package org.archive.cdxserver.format;
+
+import java.beans.PropertyEditorSupport;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * property editor for CDXFormat property.
+ * <p>
+ * Meant to provide backward compatibility at Spring level for
+ * CDXServer {@code cdxFormat} property.
+ * Converts strings {@code cdx9} and {@code cdx11} to
+ * corresponding CDXFormat implementation.
+ * </P
+ */
+public class CDXFormatEditor extends PropertyEditorSupport {
+
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		if (!StringUtils.hasText(text)) {
+			setValue(null);
+			return;
+		}
+		if (text.equals("cdx9")) {
+			setValue(new CDX9Format());
+			return;
+		}
+		if (text.equals("cdx11")) {
+			setValue(new CDX11Format());
+			return;
+		}
+		throw new IllegalArgumentException("invalid textual name for CDXFormat");
+	}
+
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/StandardCDXFormat.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/StandardCDXFormat.java
@@ -1,0 +1,95 @@
+package org.archive.cdxserver.format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.archive.format.cdx.CDXFieldConstants;
+import org.archive.format.cdx.CDXLine;
+import org.archive.format.cdx.CDXLineFactory;
+import org.archive.format.cdx.FieldSplitFormat;
+import org.archive.format.cdx.StandardCDXLineFactory;
+
+/**
+ * Implementation of {@link CDXFormat} for traditional CDX9 and CDX11 format.
+ * <p>
+ * Serves as a bridge to traditional combination of {@link FieldSplitFormat} and
+ * {@link StandardCDXLineFactory}.
+ * You can define extended CDXFormat by providing custom {@link CDXLineFactory} implementation.
+ * StandardCDXLineFactory can only support CDX11 and CDX9 in space-delimited lines efficiently.
+ * </p>
+ * <p>
+ * This class has no convenience constructor taking symbolic format name (like {@code "cdx11"}) as
+ * the first argument, because it can be confusing.
+ * </p>
+ * <p>
+ * Note: if you ever need to make a sub-class of this class for modified traits, be sure
+ * to override {@link #copy()}, so that it {@link #extend(String...)} creates new instance of
+ * appropriate type.
+ * </p>
+ */
+public class StandardCDXFormat extends FieldSplitFormat implements CDXFormat, CDXFieldConstants {
+	// CDX11Line and CDX9Line have package-scope constructor. We need to use CDXLineFactory
+	// to create their instance.
+	private final CDXLineFactory factory;
+	
+	public StandardCDXFormat(CDXLineFactory factory, String... names) {
+		super(Arrays.asList(names));
+		this.factory = factory;
+	}
+	
+	protected StandardCDXFormat(CDXLineFactory factory, List<String> names) {
+		super(names);
+		this.factory = factory;
+	}
+
+	/**
+	 * Create new instance with the same internal data.
+	 * @return
+	 */
+	protected StandardCDXFormat copy() {
+		// need to make a copy because it will be stored as it is in
+		// FieldSplitFormat.
+		List<String> namesCopy = new ArrayList<String>(names);
+		return new StandardCDXFormat(factory, namesCopy);
+	}
+	
+	/**
+	 * Destructively add {@code newFields} to {@code names}.
+	 * @param newFields
+	 */
+	protected void addFields(List<String> newFields) {
+		// note we cannot use FieldSplitFormat.addFieldNames(String...) because it
+		// creates a new instance of FieldSplitFormat (i.e. not destructive).
+		int i = names.size();
+		for (String name : newFields) {
+			nameToIndex.put(name, i++);
+		}
+		names.addAll(newFields);
+	}
+	
+	public CDXLine createCDXLine(String input) {
+		return factory.createStandardCDXLine(input, this);
+	}
+	
+	public boolean isRevisit(CDXLine line) {
+		// standard revisit representation: mimetype is "warc/revisit" (WARC) or
+		// filename is empty ("-") (ARC)
+		return line.getMimeType().equals("warc/revisit") ||
+				line.getFilename().equals(CDXLine.EMPTY_VALUE);
+	}
+	
+	@Override
+	public FieldSplitFormat getFields() {
+		return this;
+	}
+
+	@Override
+	public final CDXFormat extend(String... moreFields) {
+		if (moreFields.length == 0)
+			return this;
+		StandardCDXFormat extended = copy();
+		extended.addFields(Arrays.asList(moreFields));
+		return extended;
+	}
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/BaseProcessor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/BaseProcessor.java
@@ -1,8 +1,9 @@
 package org.archive.cdxserver.processor;
 
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.cdxserver.writer.CDXWriter;
+import org.archive.format.cdx.CDXFieldConstants;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
 /**
  * {@code BaseProcessor} is an interface for a receiver
@@ -69,12 +70,13 @@ public interface BaseProcessor {
 
 	/**
 	 * Return output format (list of fields), given input format {@code format}.
-	 * Intermediaries should call {@code modifyOutputFormat(format)} on nested
-	 * processor first, then make appropriate changes to it if they add/remove
-	 * fields.
+	 * Intermediaries, if they add/remove fields, should make appropriate changes
+	 * to it first, then call {@code modifyOutputFormat(format)} on downstream
+	 * processors, because downstream processors may configure themselves based on
+	 * the format they see.
 	 * @param format input format
 	 * @return output format
 	 * @see CDXFieldConstants
 	 */
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format);
+	public CDXFormat modifyOutputFormat(CDXFormat format);
 }

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/DupeCountProcessor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/DupeCountProcessor.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
 public class DupeCountProcessor extends WrappedProcessor {
 
@@ -54,11 +53,12 @@ public class DupeCountProcessor extends WrappedProcessor {
     }
 
 	@Override
-    public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format) {
-        if (showDupeCount) {
-            format = super.modifyOutputFormat(format).addFieldNames(dupecount);
-        }
-        
-        return format;
-    }
+	protected String[] extraFields() {
+		if (showDupeCount) {
+			return new String[] { dupecount };
+		} else {
+			return null;
+		}
+	}
+	
 }

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/FieldSelectorProcessor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/FieldSelectorProcessor.java
@@ -1,0 +1,72 @@
+package org.archive.cdxserver.processor;
+
+import org.archive.cdxserver.format.CDXFormat;
+import org.archive.format.cdx.CDXLine;
+import org.archive.format.cdx.FieldSplitFormat;
+
+/**
+ * Processor that selects specified fields in specified order.
+ * <p>
+ * This processor is inserted just before the final CDX writer,
+ * and creates new CDXLine with only those fields that goes out
+ * in the output, if output fields are different from original
+ * index format.
+ * </p>
+ * <p>
+ * Note {@link CDXLine} passed downstream will have raw {@link FieldSplitFormat}
+ * object as {@code names} if this processor actually takes effect. Therefore,
+ * no further processing shall be done except for writing out to the final output.
+ * </p>
+ * @author kenji
+ *
+ */
+public class FieldSelectorProcessor extends WrappedProcessor {
+	private FieldSplitFormat allowedFields;
+	
+	private FieldSplitFormat outputFields;
+	
+	/**
+	 * Initialize with {@code outputFields} and {@code allowedFields}.
+	 * <p>
+	 * Note if both {@code outputFields} and {@code allowedFields} are {@code null},
+	 * There's no point using this processor.
+	 * </p>
+	 * @param downstream downstream processor (final writer)
+	 * @param outputFields fields requested by client, may be {@code null}
+	 * @param allowedFields fields allowed for client privilege level, may be {@code null}
+	 */
+	public FieldSelectorProcessor(BaseProcessor downstream,
+			FieldSplitFormat outputFields, FieldSplitFormat allowedFields) {
+		super(downstream);
+		if (allowedFields != null && outputFields != null) {
+			outputFields = allowedFields.createSubset(outputFields);
+		}
+		this.allowedFields = allowedFields;
+		this.outputFields = outputFields;
+	}
+	
+	@Override
+	public int writeLine(CDXLine line) {
+		if (outputFields != null) {
+			line = new CDXLine(line, outputFields);
+		}
+		return super.writeLine(line);
+	}
+	
+	@Override
+	public CDXFormat modifyOutputFormat(CDXFormat format) {
+		// assumes format has all fields added by upstream. for this
+		// reason, upstream processor must call downstream modifyOutputFormat()
+		// after adding fields they use.
+		if (outputFields != null) {
+			// allowedFields is already applied if non-null
+			outputFields = format.getFields().createSubset(outputFields);
+		} else if (allowedFields != null) {
+			outputFields = allowedFields.createSubset(format.getFields());
+		} else {
+			// if outputFields is null and allowedFields is null, no need for
+			// selecting. outputFields can remain null.
+		}
+		return super.modifyOutputFormat(format);
+	}
+}

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/GroupCountProcessor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/GroupCountProcessor.java
@@ -1,9 +1,10 @@
 package org.archive.cdxserver.processor;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
 public class GroupCountProcessor extends WrappedProcessor {
 	
@@ -86,21 +87,18 @@ public class GroupCountProcessor extends WrappedProcessor {
 	}
 	
 	@Override
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format)
-	{
-		format = super.modifyOutputFormat(format).addFieldNames(groupcount);
-		
+	protected String[] extraFields() {
+		List<String> fields = new ArrayList<String>();
+		fields.add(groupcount);
 		if (writeLastTimestamp) {
-			format = format.addFieldNames(endtimestamp);
+			fields.add(endtimestamp);
 		}
-		
 		if (uniqDigestSet != null) {
-			format = format.addFieldNames(uniqcount);
+			fields.add(uniqcount);
 		}
-		
-		return format;
+		return fields.toArray(new String[fields.size()]);
 	}
-
+	
 	@Override
 	public void writeResumeKey(String resumeKey) {
 		this.writeDeferredLine();

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/RevisitResolver.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/RevisitResolver.java
@@ -1,7 +1,7 @@
 package org.archive.cdxserver.processor;
 
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
 public abstract class RevisitResolver extends DupeCountProcessor {
 
@@ -29,16 +29,16 @@ public abstract class RevisitResolver extends DupeCountProcessor {
 	}
     
 	protected static boolean isRevisit(CDXLine line) {
-		return (line.getMimeType().equals("warc/revisit") || line.getFilename()
-			.equals(CDXLine.EMPTY_VALUE));
+		return ((CDXFormat)line.getNames()).isRevisit(line);
+//		return (line.getMimeType().equals("warc/revisit") || line.getFilename()
+//			.equals(CDXLine.EMPTY_VALUE));
 	}
     
 	@Override
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format) {
-		format = super.modifyOutputFormat(format).addFieldNames(origlength, origoffset, origfilename);
-		return format;
+	protected String[] extraFields() {
+		return new String[] { origlength, origoffset, origfilename };
 	}
-
+	
 	static abstract class RevisitTrack extends DupeTrack {
 		abstract void revisit(CDXLine line);
 		abstract void original(CDXLine line);

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/WrappedProcessor.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/processor/WrappedProcessor.java
@@ -1,14 +1,18 @@
 package org.archive.cdxserver.processor;
 
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
+/**
+ * Base class for intermediary processors.
+ * 
+ * Note: {@code inner} processor is downstream (closer to the final output processor).
+ */
 public class WrappedProcessor implements BaseProcessor {
 	
 	protected BaseProcessor inner;
 	
-	public WrappedProcessor(BaseProcessor output)
-	{
+	public WrappedProcessor(BaseProcessor output) {
 		this.inner = output;
 	}
 
@@ -38,7 +42,28 @@ public class WrappedProcessor implements BaseProcessor {
 	}
 	
 	@Override
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format) {
+	public CDXFormat modifyOutputFormat(CDXFormat format) {
+		String[] moreFields = extraFields();
+		if (moreFields != null && moreFields.length > 0) {
+			format = format.extend(moreFields);
+		}
 		return inner.modifyOutputFormat(format);
+	}
+	
+	/**
+	 * Return an array of field names to add to the format for
+	 * {@link WaybackCDXLineFactory}.
+	 * <p>
+	 * Return {@code null} if processor does not need additional fields
+	 * (base implementation).
+	 * </p>
+	 * <p>
+	 * If intermediary processor ever removes fields, it should override
+	 * {@link #modifyOutputFormat(CDXFormat)}.
+	 * </p>
+	 * @return
+	 */
+	protected String[] extraFields() {
+		return null;
 	}
 }

--- a/wayback-cdx-server/src/main/java/org/archive/cdxserver/writer/CDXWriter.java
+++ b/wayback-cdx-server/src/main/java/org/archive/cdxserver/writer/CDXWriter.java
@@ -1,8 +1,8 @@
 package org.archive.cdxserver.writer;
 
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.cdxserver.processor.BaseProcessor;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 
 public abstract class CDXWriter implements BaseProcessor {
 
@@ -35,7 +35,7 @@ public abstract class CDXWriter implements BaseProcessor {
 	}
 
 	@Override
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format) {
+	public CDXFormat modifyOutputFormat(CDXFormat format) {
 		return format;
 	}
 

--- a/wayback-cdx-server/src/test/java/org/archive/cdxserver/StandardCDXFormatTest.java
+++ b/wayback-cdx-server/src/test/java/org/archive/cdxserver/StandardCDXFormatTest.java
@@ -1,0 +1,95 @@
+/**
+ * 
+ */
+package org.archive.cdxserver;
+
+import junit.framework.TestCase;
+
+import org.archive.cdxserver.format.CDX11Format;
+import org.archive.cdxserver.format.CDX9Format;
+import org.archive.cdxserver.format.CDXFormat;
+import org.archive.cdxserver.format.StandardCDXFormat;
+import org.archive.format.cdx.CDXFieldConstants;
+import org.archive.format.cdx.CDXLine;
+import org.archive.format.cdx.FieldSplitFormat;
+
+/**
+ * Test for StandardCDXFormatTest
+ */
+public class StandardCDXFormatTest extends TestCase implements CDXFieldConstants {
+
+	static final StandardCDXFormat cdx11Format = new CDX11Format();
+	static final StandardCDXFormat cdx9Format = new CDX9Format();
+	
+	/* (non-Javadoc)
+	 * @see junit.framework.TestCase#setUp()
+	 */
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
+	
+	public void testFields() {
+		CDXLine line = cdx11Format.createCDXLine("com,example)/ 20100101232959 http://example.com " +
+				"text/html 200 SHASHASHA - - 200 10000 a/b.warc.gz");
+		
+		int indexOffset = line.getFieldIndex(offset);
+		assertEquals(9, indexOffset);
+		
+		String valueOffset = line.getField(indexOffset);
+		assertEquals("10000", valueOffset);
+		
+		assertEquals("text/html", line.getMimeType());
+		
+		assertFalse(cdx11Format.isRevisit(line));
+	}
+	
+	public void testCDX9() {
+		assertEquals(9, cdx9Format.getFields().getLength());
+		
+		CDXLine line = cdx9Format.createCDXLine("com,example)/ 20100101232959 http://example.com " +
+	"text/html 200 SHASHASHASHA - 10000 a/b.warc.gz");
+		
+		int indexOffset = line.getFieldIndex(offset);
+		assertEquals(7, indexOffset);
+		
+		String valueOffset = line.getField(indexOffset);
+		assertEquals("10000", valueOffset);
+		
+		assertEquals("text/html", line.getMimeType());
+		
+		assertFalse(cdx9Format.isRevisit(line));
+	}
+	
+	public void testExtend() {
+		final String FIELD1 = "field1", FIELD2 = "field2", FIELD3 = "field3";
+		CDXFormat format = cdx11Format.extend(FIELD1, FIELD2, FIELD3);
+		
+		assertTrue(format instanceof StandardCDXFormat);
+		
+		FieldSplitFormat names = format.getFields();
+		assertEquals(11 + 3, names.getLength());
+		
+		// index -> name mapping
+		assertEquals(filename, names.getName(10));
+		assertEquals(FIELD1, names.getName(11));
+		assertEquals(FIELD3, names.getName(13));
+		
+		// name -> index mapping
+		assertEquals(10, names.getFieldIndex(filename));
+		assertEquals(11, names.getFieldIndex(FIELD1));
+		assertEquals(13, names.getFieldIndex(FIELD3));
+		
+		// name -> index mapping at CDXFormat level
+		assertEquals(11, format.getFieldIndex(FIELD1));
+	}
+	
+	/**
+	 * {@link StandardCDXFormat#extend(String...)} without arguments
+	 * shall return the same object.
+	 */
+	public void testExtendNothing() {
+		CDXFormat format = cdx11Format.extend();
+		assertSame(cdx11Format, format);
+	}
+
+}

--- a/wayback-cdx-server/src/test/java/org/archive/cdxserver/processor/FieldSelectorProcessorTest.java
+++ b/wayback-cdx-server/src/test/java/org/archive/cdxserver/processor/FieldSelectorProcessorTest.java
@@ -1,0 +1,156 @@
+package org.archive.cdxserver.processor;
+
+import junit.framework.TestCase;
+
+import org.archive.cdxserver.format.CDX11Format;
+import org.archive.cdxserver.format.CDXFormat;
+import org.archive.format.cdx.CDXLine;
+import org.archive.format.cdx.FieldSplitFormat;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+
+/**
+ * Test for FieldSelectorProcessor
+ *
+ */
+public class FieldSelectorProcessorTest extends TestCase {
+
+	final static CDXFormat cdxFormat = new CDX11Format();
+
+	final static String CDXLINE = "com,exmaple)/ 20100101232959 http://example.com/ text/html "
+			+ "200 SHASHASHASHA - - 200 10000 a/b.warc.gz";
+
+	class CdxOut implements BaseProcessor {
+		FieldSplitFormat expectedFormat;
+
+		public CdxOut(FieldSplitFormat expectedFormat) {
+			this.expectedFormat = expectedFormat;
+		}
+
+		public CdxOut(String expectedFormat) {
+			this(new FieldSplitFormat(expectedFormat));
+		}
+
+		@Override
+		public void begin() {
+		}
+
+		@Override
+		public void trackLine(CDXLine line) {
+		}
+
+		@Override
+		public void writeResumeKey(String resumeKey) {
+		}
+
+		@Override
+		public void end() {
+		}
+
+		@Override
+		public CDXFormat modifyOutputFormat(CDXFormat format) {
+			return format;
+		}
+
+		@Override
+		public int writeLine(CDXLine line) {
+			assertTrue(line.getNumFields() == expectedFormat.getLength());
+			for (int i = 0; i < line.getNumFields(); i++) {
+				int idx = line.getFieldIndex(expectedFormat.getName(i));
+				assertEquals(i, idx);
+			}
+			return 1;
+		}
+
+	}
+
+	class AnswerWriteLine implements IAnswer<Integer> {
+		FieldSplitFormat expectedFormat;
+
+		public AnswerWriteLine(FieldSplitFormat expectedFormat) {
+			this.expectedFormat = expectedFormat;
+		}
+
+		public AnswerWriteLine(String expectedFormat) {
+			this(new FieldSplitFormat(expectedFormat));
+		}
+
+		@Override
+		public Integer answer() throws Throwable {
+			CDXLine line = (CDXLine)EasyMock.getCurrentArguments()[0];
+			assertEquals(expectedFormat.getLength(), line.getNumFields());
+			// check line has the same fields as expectedFormat, in the same
+			// order.
+			for (int i = 0; i < line.getNumFields(); i++) {
+				int idx = line.getFieldIndex(expectedFormat.getName(i));
+				assertEquals(expectedFormat.getName(i), i, idx);
+			}
+			return 1;
+		}
+	}
+
+	BaseProcessor writer;
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		writer = EasyMock.createNiceMock(BaseProcessor.class);
+		EasyMock.expect(writer.modifyOutputFormat(cdxFormat)).andReturn(
+			cdxFormat);
+		// each test should set up writeLine().
+	}
+
+	protected void expectWriteLine(String expectedFormat) {
+		EasyMock.expect(writer.writeLine(EasyMock.<CDXLine>notNull()))
+			.andAnswer(new AnswerWriteLine(expectedFormat));
+	}
+
+	protected void runWriteLineTest(FieldSplitFormat outputFields,
+			FieldSplitFormat allowedFields, String expectedFormat) {
+		expectWriteLine(expectedFormat);
+
+		EasyMock.replay(writer);
+
+		FieldSelectorProcessor selector = new FieldSelectorProcessor(writer,
+			outputFields, allowedFields);
+		CDXFormat parseFormat = selector.modifyOutputFormat(cdxFormat);
+		CDXLine line = parseFormat.createCDXLine(CDXLINE);
+		selector.writeLine(line);
+	}
+
+	public void testNullOutputNullAllowed() {
+		runWriteLineTest(
+			null,
+			null,
+			"urlkey,timestamp,original,mimetype,statuscode,digest,redirect,robotflags,length,offset,filename");
+	}
+
+	public void testNullOputput() {
+		runWriteLineTest(
+			null,
+			new FieldSplitFormat("urlkey,timestamp,original,mimetype,statuscode,digest,length"),
+			"urlkey,timestamp,original,mimetype,statuscode,digest,length"
+			);
+	}
+	
+	public void testNullAllowed() {
+		runWriteLineTest(
+			new FieldSplitFormat("original,timestamp,mimetype,statuscode,offset,filename"),
+			null,
+			"original,timestamp,mimetype,statuscode,offset,filename");
+	}
+	
+	public void testBothNotNull() {
+		runWriteLineTest(
+			new FieldSplitFormat("original,timestamp,mimetype,statuscode,offset,filename"),
+			new FieldSplitFormat("urlkey,timestamp,original,mimetype,statuscode,digest,length"),
+			"original,timestamp,mimetype,statuscode");
+	}
+	
+	public void testUndefinedFieldInAllowed() {
+		runWriteLineTest(
+			new FieldSplitFormat("original,timestamp,mimetype,statuscode,offset,filename"),
+			new FieldSplitFormat("urlkey,timestamp,original,mimetype,statuscode,digest,length,groupcount"),
+			"original,timestamp,mimetype,statuscode");
+		
+	}
+}

--- a/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/CDXToSearchResultWriter.java
+++ b/wayback-core/src/main/java/org/archive/wayback/resourceindex/cdxserver/CDXToSearchResultWriter.java
@@ -2,9 +2,9 @@ package org.archive.wayback.resourceindex.cdxserver;
 
 import org.archive.cdxserver.CDXQuery;
 import org.archive.cdxserver.CDXServer;
+import org.archive.cdxserver.format.CDXFormat;
 import org.archive.cdxserver.writer.CDXWriter;
 import org.archive.format.cdx.CDXLine;
-import org.archive.format.cdx.FieldSplitFormat;
 import org.archive.wayback.ResourceIndex;
 import org.archive.wayback.core.SearchResults;
 
@@ -64,7 +64,7 @@ public abstract class CDXToSearchResultWriter extends CDXWriter {
 	}
 
 	@Override
-	public FieldSplitFormat modifyOutputFormat(FieldSplitFormat format) {
+	public CDXFormat modifyOutputFormat(CDXFormat format) {
 		return format;
 	}
 }


### PR DESCRIPTION
format and field interpretation change -- we are adding more fields to CDX and also changing how revisit records are represented in CDX line. This change will allow us to make that change without affecting other deployment using traditional CDX11/CDX9.
There should be no change to external behavior, except for `CDXServer.cdxFormat` property whose type has changed from `String` to `CDXFormat`;
it is backward compatible at Spring configuration level thanks to property editor for `CDXFormat`.

`CDXLineFactory` and `FieldSplitFormat` are encapsulated in new interface `CDXFormat`, through which revisit detection can be customized.
CDXLine Processor constructor signature has changed. `modifyOutputFormat` behavior has changed (now it must add fields before calling downstream).
For any deployment using custom processor, this can be a breaking change (unlikely, I hope)
As a side effect, resolveRevisit bug is fixed (WWM-978).