### PR TITLE
still larger buffer for instagram js character set detection

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
@@ -12,7 +12,7 @@ import com.ibm.icu.text.CharsetMatch;
  */
 public class UniversalChardetSniffer extends BaseEncodingSniffer {
 	// hand off this many bytes to the chardet library
-	protected final static int MAX_CHARSET_READAHEAD = 98304;
+	protected final static int MAX_CHARSET_READAHEAD = 131072;
 
 	@Override
 	public String sniff(Resource resource) {


### PR DESCRIPTION
enables replay of recent instagram captures, by correcting character set assigned to https://www.instagram.com/static/bundles/metro/ProfilePageContainer.js/703c305a5ed5.js
from ISO-8859-1 to UTF-8, for [ARI-5915]( https://webarchive.jira.com/browse/ARI-5915)