### PR TITLE
don't detect UTF-32 charset

### DIFF
--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
@@ -29,16 +29,26 @@ public class UniversalChardetSniffer extends BaseEncodingSniffer {
 
 			detector.setText(bbuffer);
 			CharsetMatch[] matches = detector.detectAll();
-			if (matches != null && matches.length > 0) {
-				charsetName = matches[0].getName();
+			if (matches != null) {
+				for (int i = 0; i < matches.length; i++) {
+					charsetName = matches[i].getName();
+					if (!isDubious(charsetName) && isCharsetSupported(charsetName)) {
+						return charsetName;
+					}
+				}
 			}
-
 		} catch (IOException ex) {
 			//
 		}
-		if (isCharsetSupported(charsetName)) {
-			return charsetName;
-		}
 		return null;
+	}
+
+	/*
+	 * Pretty much nothing in the wild is really UTF-32,
+	 * yet icu4j returns that as the likeliest possiblity
+	 * for several captures...
+	 */
+	protected boolean isDubious(String charsetName) {
+		return charsetName.startsWith("UTF-32");
 	}
 }


### PR DESCRIPTION
The icu4j library is surprisingly returning UTF-32 charsets as the most probable (though still not _very_ probable) charset for elements of several recent captures. icu4j also returns, in these cases, UTF-8, with somewhat lower probability. We should skip returning UTF-32 and just return UTF-8.

for https://webarchive.jira.com/browse/ARI-5907