### PR TITLE
remove non existent section from TOC

### DIFF
--- a/wayback-cdx-server/README.md
+++ b/wayback-cdx-server/README.md
@@ -11,7 +11,7 @@
 
 ##### Table of Contents
 
-#### [Intro and Usage](#intro-and-usage)
+#### [Intro and Usage](#intro-and-usage-1)
 
 * [Changelist](#changelist)
 
@@ -29,14 +29,10 @@
 
 * [Query Result Limits](#query-result-limits)
 
-#### [Advanced Usage](#advanced-usage) 
+#### [Advanced Usage](#advanced-usage-1) 
 
-* [Closest Timestamp Match](#closest-timestamp-match)
+* [Resumption Key](#resumption-key)
 
-* [Resumption Key](#resumption)
-
-* [Resolve Revisits](#resolve-revisits)
-  
 * [Counters](#counters)
 
   * [Duplicate Counter](#duplicate-counter)


### PR DESCRIPTION
I was working on a [wrapper for the Cdx API](https://github.com/akamhy/waybackpy) and found that some sections in the TOC weren't available. I've removed them from the TOC and fixed links that were linking to themselves. 