### PR TITLE
Prefer UTF-8 character set if it can be sniffed out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
+dist: xenial
 language: java
 jdk:
-  - oraclejdk8
-  # no longer available
-  #- oraclejdk7
-  - openjdk7
+  - openjdk8
+  - openjdk10
 branches:
   only:
     - master

--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
@@ -40,7 +40,7 @@ public class UniversalChardetSniffer extends BaseEncodingSniffer {
 					    if (charsetNextBest == null) { charsetNextBest = charsetName; }
 
 					    // prefer UTF character sets
-					    if (charsetName.startsWith("UTF")) { return charsetName; }
+					    if (charsetName.startsWith("UTF-8")) { return charsetName; }
 					}
 				}
 			    

--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
@@ -54,7 +54,7 @@ public class UniversalChardetSniffer extends BaseEncodingSniffer {
 
 	/*
 	 * Pretty much nothing in the wild is really UTF-32,
-	 * yet icu4j returns that as the likeliest possiblity
+	 * yet icu4j returns that as the likeliest possibility
 	 * for several captures...
 	 */
 	protected boolean isDubious(String charsetName) {

--- a/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
+++ b/wayback-core/src/main/java/org/archive/wayback/replay/charset/UniversalChardetSniffer.java
@@ -30,12 +30,21 @@ public class UniversalChardetSniffer extends BaseEncodingSniffer {
 			detector.setText(bbuffer);
 			CharsetMatch[] matches = detector.detectAll();
 			if (matches != null) {
-				for (int i = 0; i < matches.length; i++) {
+
+			    String charsetNextBest = null;
+			    
+			    for (int i = 0; i < matches.length; i++) {
 					charsetName = matches[i].getName();
 					if (!isDubious(charsetName) && isCharsetSupported(charsetName)) {
-						return charsetName;
+					    
+					    if (charsetNextBest == null) { charsetNextBest = charsetName; }
+
+					    // prefer UTF character sets
+					    if (charsetName.startsWith("UTF")) { return charsetName; }
 					}
 				}
+			    
+			    return charsetNextBest;
 			}
 		} catch (IOException ex) {
 			//


### PR DESCRIPTION
This change will default to using UTF-8 character encoding if it's detected as a match. If it's not it will return the first match it finds or nothing.